### PR TITLE
added ad unit in footer with DFP

### DIFF
--- a/_includes/dfp-script.html
+++ b/_includes/dfp-script.html
@@ -1,0 +1,27 @@
+<script type='text/javascript'>
+    var googletag = googletag || {};
+    googletag.cmd = googletag.cmd || [];
+    (function() {
+    var gads = document.createElement('script');
+    gads.async = true;
+    gads.type = 'text/javascript';
+    var useSSL = 'https:' == document.location.protocol;
+    gads.src = (useSSL ? 'https:' : 'http:') +
+      '//www.googletagservices.com/tag/js/gpt.js';
+    var node = document.getElementsByTagName('script')[0];
+    node.parentNode.insertBefore(gads, node);
+    })();
+</script>
+<script type='text/javascript'>
+
+    googletag.cmd.push(function() {
+        var mapping = googletag.sizeMapping().
+          addSize([980, 690], [728, 90]).
+          addSize([0, 0], [320, 50]).
+          build();
+        googletag.defineSlot('/94788221/wucfooter', [[320,50],[728, 90]], 'div-gpt-ad-1429910991777-0').defineSizeMapping(mapping).addService(googletag.pubads());
+        googletag.pubads().enableSingleRequest();
+        googletag.pubads().collapseEmptyDivs();
+        googletag.enableServices();
+    });
+</script>

--- a/_includes/dfp.html
+++ b/_includes/dfp.html
@@ -1,0 +1,6 @@
+<!-- /94788221/wucfooter -->
+<div id='div-gpt-ad-1429910991777-0' class="dfp">
+<script type='text/javascript'>
+googletag.cmd.push(function() { googletag.display('div-gpt-ad-1429910991777-0'); });
+</script>
+</div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -20,6 +20,7 @@
     <link rel="alternate" type="application/rss+xml" title="{{ site.name }} - {{ site.description }}" href="{{ site.baseurl }}/feed.xml" />
 
     <!-- Created with Jekyll Now -->
+    {% include dfp-script.html %}
   </head>
 
   <body>
@@ -53,6 +54,7 @@
     <div class="wrapper-footer">
       <div class="container">
         <footer class="footer">
+          {% include dfp.html %}
           {% include email-form.html %}
           <p>
         | <a href="{{ site.baseurl }}/de/">Deutsch</a> | 

--- a/style.scss
+++ b/style.scss
@@ -283,6 +283,13 @@ footer {
   text-align: center;
 }
 
+.dfp {
+  margin-bottom: 20px;
+  @media screen and (min-width: 748px) {
+    margin-left: -4px;
+  }
+}
+
 .widget-wrapper {
   margin: 20px;
   text-align: center;


### PR DESCRIPTION
I setup the ad unit so that it display a 728x90 ad on large displays and a 320x50 mobile leaderboard on mobile. I only added it do the default.html layout but it would be simple to include in others as well. Minimal styling necessary for spacing.