### PR TITLE
Add chart pages

### DIFF
--- a/assets/js/bitcoin-charts.js
+++ b/assets/js/bitcoin-charts.js
@@ -206,7 +206,7 @@ var BitcoinCharts = {
       });
     }).done(function(){
       // Draw the chart with the data and options.
-      var priceChart = new Chart(ctx).LineCompact(chartData, chartOptions);
+      new Chart(ctx).LineCompact(chartData, chartOptions);
     });
   }
 };

--- a/en/charts/average-block-size.md
+++ b/en/charts/average-block-size.md
@@ -1,0 +1,12 @@
+---
+title: Average Block Size
+chart: true
+charts:
+  - averageBlockSize
+---
+
+<h2>{{ page.title }}</h2>
+
+<canvas id="average-block-size-chart" class="chart" height="150" style="width:100%;"></canvas>
+
+<a href="{{ site.baseurl }}/{{ page.lang }}/charts">Back to charts</a>

--- a/en/charts/average-transaction-fees.md
+++ b/en/charts/average-transaction-fees.md
@@ -1,0 +1,12 @@
+---
+title: Average Transaction Fees
+chart: true
+charts:
+  - averageTransactionFees
+---
+
+<h2>{{ page.title }}</h2>
+
+<canvas id="average-transaction-fees-chart" class="chart" height="150" style="width:100%;"></canvas>
+
+<a href="{{ site.baseurl }}/{{ page.lang }}/charts">Back to charts</a>

--- a/en/charts/average-volume-per-transaction.md
+++ b/en/charts/average-volume-per-transaction.md
@@ -1,0 +1,12 @@
+---
+title: Average Volume per Transaction
+chart: true
+charts:
+  - averageVolumePerTransaction
+---
+
+<h2>{{ page.title }}</h2>
+
+<canvas id="average-volume-per-transaction-chart" class="chart" height="150" style="width:100%;"></canvas>
+
+<a href="{{ site.baseurl }}/{{ page.lang }}/charts">Back to charts</a>

--- a/en/charts/blockchain-size.md
+++ b/en/charts/blockchain-size.md
@@ -1,0 +1,12 @@
+---
+title: Blockchain Size
+chart: true
+charts:
+  - blockchainSize
+---
+
+<h2>{{ page.title }}</h2>
+
+<canvas id="blockchain-size-chart" class="chart" height="150" style="width:100%;"></canvas>
+
+<a href="{{ site.baseurl }}/{{ page.lang }}/charts">Back to charts</a>

--- a/en/charts/blocks-per-day.md
+++ b/en/charts/blocks-per-day.md
@@ -1,0 +1,12 @@
+---
+title: Blocks per Day
+chart: true
+charts:
+  - blocksPerDay
+---
+
+<h2>{{ page.title }}</h2>
+
+<canvas id="blocks-per-day-chart" class="chart" height="150" style="width:100%;"></canvas>
+
+<a href="{{ site.baseurl }}/{{ page.lang }}/charts">Back to charts</a>

--- a/en/charts/coins-in-circulation.md
+++ b/en/charts/coins-in-circulation.md
@@ -1,0 +1,12 @@
+---
+title: Coins in Circulation
+chart: true
+charts:
+  - coinsInCirculation
+---
+
+<h2>{{ page.title }}</h2>
+
+<canvas id="coins-in-circulation-chart" class="chart" height="150" style="width:100%;"></canvas>
+
+<a href="{{ site.baseurl }}/{{ page.lang }}/charts">Back to charts</a>

--- a/en/charts/difficulty.md
+++ b/en/charts/difficulty.md
@@ -1,0 +1,12 @@
+---
+title: Difficulty
+chart: true
+charts:
+  - difficulty
+---
+
+<h2>{{ page.title }}</h2>
+
+<canvas id="difficulty-chart" class="chart" height="150" style="width:100%;"></canvas>
+
+<a href="{{ site.baseurl }}/{{ page.lang }}/charts">Back to charts</a>

--- a/en/charts/hash-rate.md
+++ b/en/charts/hash-rate.md
@@ -1,0 +1,12 @@
+---
+title: Hash Rate
+chart: true
+charts:
+  - hashRate
+---
+
+<h2>{{ page.title }}</h2>
+
+<canvas id="hash-rate-chart" class="chart" height="150" style="width:100%;"></canvas>
+
+<a href="{{ site.baseurl }}/{{ page.lang }}/charts">Back to charts</a>

--- a/en/charts/index.md
+++ b/en/charts/index.md
@@ -1,0 +1,12 @@
+---
+title: Charts
+---
+{% assign charts = site.pages|where:'chart','true'|where:'lang',page.lang %}
+
+<h2>{{ page.title }}</h2>
+All charts:
+<ul>
+{% for chart in charts %}
+  <li><a href="{{ chart.url }}">{{ chart.title }}</a></li>
+{% endfor %}
+</ul>

--- a/en/charts/outputs-volume.md
+++ b/en/charts/outputs-volume.md
@@ -1,0 +1,12 @@
+---
+title: Outputs Volume
+chart: true
+charts:
+  - outputsVolume
+---
+
+<h2>{{ page.title }}</h2>
+
+<canvas id="outputs-volume-chart" class="chart" height="150" style="width:100%;"></canvas>
+
+<a href="{{ site.baseurl }}/{{ page.lang }}/charts">Back to charts</a>

--- a/en/charts/price.md
+++ b/en/charts/price.md
@@ -1,0 +1,19 @@
+---
+title: Bitcoin Price Chart
+chart: true
+charts:
+  - priceUSD
+  #- priceEUR broken not sure why
+  #- priceCNY broken not sure why
+---
+
+<h2>{{ page.title }}</h2>
+<h3>USD</h3>
+<canvas id="price-chart-usd" class="chart" height="150" style="width:100%;"></canvas>
+<!-- broken for some reason
+<h3>Euro</h3>
+<canvas id="price-chart-eur" class="chart" height="150" style="width:100%;"></canvas>
+<h3>CNY</h3>
+<canvas id="price-chart-cny" class="chart" height="150" style="width:100%;"></canvas>-->
+
+<a href="{{ site.baseurl }}/{{ page.lang }}/charts">Back to charts</a>

--- a/en/charts/transaction-fees.md
+++ b/en/charts/transaction-fees.md
@@ -1,0 +1,12 @@
+---
+title: Transaction Fees
+chart: true
+charts:
+  - transactionFees
+---
+
+<h2>{{ page.title }}</h2>
+
+<canvas id="transaction-fees-chart" class="chart" height="150" style="width:100%;"></canvas>
+
+<a href="{{ site.baseurl }}/{{ page.lang }}/charts">Back to charts</a>

--- a/en/charts/transactions-per-block.md
+++ b/en/charts/transactions-per-block.md
@@ -1,0 +1,12 @@
+---
+title: Transactions per Block
+chart: true
+charts:
+  - transactionsPerBlock
+---
+
+<h2>{{ page.title }}</h2>
+
+<canvas id="transactions-per-block-chart" class="chart" height="150" style="width:100%;"></canvas>
+
+<a href="{{ site.baseurl }}/{{ page.lang }}/charts">Back to charts</a>

--- a/en/charts/transactions-per-day.md
+++ b/en/charts/transactions-per-day.md
@@ -1,0 +1,12 @@
+---
+title: Transactions per Day
+chart: true
+charts:
+  - transactionsPerDay
+---
+
+<h2>{{ page.title }}</h2>
+
+<canvas id="transactions-per-day-chart" class="chart" height="150" style="width:100%;"></canvas>
+
+<a href="{{ site.baseurl }}/{{ page.lang }}/charts">Back to charts</a>


### PR DESCRIPTION
Prices are broken for now. I'm working on a fix, if you enable multiple price charts on one page they get merged for some reason. All other charts are working and there's a list available at /en/charts.

Those are translateable, as they're saved in pages. I'll probably create a template for them, after that they can be used similar to a collection.