### PR TITLE
Remove broken redirects, optimize profile pages.

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -1,14 +1,14 @@
 ---
 layout: default
 ---
-<article class="page {% if page.position %}person-page{% endif %}">
+<article class="page">
 
-  <h1>{{ page.title }}{% if page.position %} - {{ page.position }}{% endif %}</h1>
+  <h1>{{ page.title }}</h1>
 
   <div class="entry">
     {{ content }}
   </div>
 
-  {% include recommendedposts.html %}
-  {% include disqus.html %}
+  {% unless page.disable_recommended %}{% include recommendedposts.html %}{% endunless %}
+  {% unless page.disable_disqus %}{% include disqus.html %}{% endunless %}
 </article>

--- a/_layouts/person.html
+++ b/_layouts/person.html
@@ -1,57 +1,49 @@
 ---
-layout: page
+layout: default
 ---
-{% if page.img or page.position %}
-<div class="person-info">
-{% if page.img %}
-	<div class="person-img-wrap">
-		<img src="{{ page.img }}" alt="{{ page.title }}">
+<article class="page person-page">
+	<h1>{{ page.title }}{% if page.position %} - {{ page.position }}{% endif %}</h1>
+
+  <div class="entry">
+		{% if page.img or page.position %}
+		<div class="person-info">
+			{% if page.img %}
+			<div class="person-img-wrap">
+				<img src="{{ page.img }}" alt="{{ page.title }}">
+			</div>
+			{% endif %}
+			<div class="person-details">
+				{% if page.position != null %}<p><span>Position</span>: {{ page.position }}</p>{% endif %}
+				{% if page.education != null %}<p><span>Education</span>: {{ page.education }}</p>{% endif %}
+				{% if page.website != null %}<p><span>Website</span>: <a href="{{ page.website }}">{{ page.website }}</a></p>{% endif %}
+				{% if page.twitter != null %}<p><span>Twitter</span>: <a href="https://twitter.com/{{ page.twitter }}">@{{ page.twitter }}</a></p>{% endif %}
+				{% if page.github != null %}<p><span>GitHub</span>: <a href="https://github.com/{{ page.github }}">@{{ page.github }}</a></p>{% endif %}
+			</div>
+		</div>
+		{% endif %}
+
+		{{ content }}
+
+		{% assign relatedArticles = site.posts | where:"author", page.title %}
+		{% if relatedArticles != empty %}
+			<h2>Bitcoin articles by or related to {{ page.title }}</h2>
+			<ul>
+				{% for articleBy in relatedArticles %}
+					<li><a href="{{ articleBy.url }}">{{ articleBy.title }}</a></li>
+				{% endfor %}
+			</ul>
+		{% endif %}
+
+		{% assign relatedPages = site.pages | where:"author", page.title %}
+		{% if relatedPages != empty %}
+			<h2>Pages by or related to {{ page.title }}</h2>
+			<ul>
+				{% for pageBy in relatedPages %}
+					<li><a href="{{ pageBy.url }}">{{ pageBy.title }}</a></li>
+				{% endfor %}
+			</ul>
+		{% endif %}
 	</div>
-{% endif %}
-<div class="person-details">
-	{% if page.position != null %}<p><span>Position</span>: {{ page.position }}</p>{% endif %}
-	{% if page.education != null %}<p><span>Education</span>: {{ page.education }}</p>{% endif %}
-	{% if page.website != null %}<p><span>Website</span>: <a href="{{ page.website }}">{{ page.website }}</a></p>{% endif %}
-	{% if page.twitter != null %}<p><span>Twitter</span>: <a href="https://twitter.com/{{ page.twitter }}">@{{ page.twitter }}</a></p>{% endif %}
-	{% if page.github != null %}<p><span>GitHub</span>: <a href="https://github.com/{{ page.github }}">@{{ page.github }}</a></p>{% endif %}
-</div>
-</div>
-{% endif %}
-
-{{ content }}
-
-{% for post in site.posts %}
-	{% if post.author == page.title %}
-		{% assign hasPosts = true %}
-		{% break %}
-	{% endif %}
-{% endfor %}
-
-{% if hasPosts %}
-	<h2>Bitcoin articles by or related to {{ page.title }}</h2>
-	<ul>
-		{% for post in site.posts %}
-			{% if post.author == page.title %}
-				<li><a href="{{ post.url }}">{{ post.title }}</a></li>
-			{% endif %}
-		{% endfor %}
-	</ul>
-{% endif %}
-
-{% for pageBy in site.pages %}
-	{% if pageBy.author == page.title %}
-		{% assign hasPages = true %}
-		{% break %}
-	{% endif %}
-{% endfor %}
-
-{% if hasPages %}
-	<h2>Pages by or related to {{ page.title }}</h2>
-	<ul>
-		{% for pageBy in site.pages %}
-			{% if pageBy.author == page.title %}
-				<li><a href="{{ pageBy.url }}">{{ pageBy.title }}</a></li>
-			{% endif %}
-		{% endfor %}
-	</ul>
-{% endif %}
+	
+  {% unless page.disable_disqus %}{% include disqus.html %}{% endunless %}
+</article>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -13,6 +13,6 @@ layout: default
     Written by <a href="{{ page.authorurl }}">{{page.author}}</a> on {{ page.date | date: "%B %e, %Y" }}.
   </div>
 
-  {% include recommendedposts.html %}
-  {% include disqus.html %}
+  {% unless page.disable_recommended %}{% include recommendedposts.html %}{% endunless %}
+  {% unless page.disable_disqus %}{% include disqus.html %}{% endunless %}
 </article>

--- a/redirects/answers-callback.html
+++ b/redirects/answers-callback.html
@@ -1,5 +1,5 @@
 ---
-permalink: /answers?site=bitcoin&sort=votes&filter=withbody&pagesize=1&callback=
+permalink: /answers
 redirect: /
 layout: redirect
 sitemap: false

--- a/redirects/redirects3/bitgold-filingpdf.html
+++ b/redirects/redirects3/bitgold-filingpdf.html
@@ -1,6 +1,0 @@
----
-permalink: "/bitgold-filing.pdf%22%3E("
-redirect: /bitgold-filing.pdf
-layout: redirect
-sitemap: false
----

--- a/redirects/redirects3/embed.html
+++ b/redirects/redirects3/embed.html
@@ -1,6 +1,0 @@
----
-permalink: "/embed.js%22%3E%3C/script%3E"
-redirect: /
-layout: redirect
-sitemap: false
----

--- a/redirects/redirects3/en-mining-guidehttp.html
+++ b/redirects/redirects3/en-mining-guidehttp.html
@@ -1,6 +1,0 @@
----
-permalink: "/en/mining-guidehttp://"
-redirect: /en/mining-guide/
-layout: redirect
-sitemap: false
----

--- a/redirects/redirects3/en.html
+++ b/redirects/redirects3/en.html
@@ -1,6 +1,0 @@
----
-permalink: "/en/:"
-redirect: /
-layout: redirect
-sitemap: false
----

--- a/redirects/redirects3/longurl.html
+++ b/redirects/redirects3/longurl.html
@@ -1,6 +1,0 @@
----
-permalink: "/%0Chttp://www.libertariannews.org/2011/05/31/how-to-use-bitcoin-the-most-important-creation-in-the-history-of-man/"
-redirect: /
-layout: redirect
-sitemap: false
----

--- a/redirects/redirects5/%22%20%5Ct%20%22_blank.html
+++ b/redirects/redirects5/%22%20%5Ct%20%22_blank.html
@@ -1,6 +1,0 @@
----
-permalink: /%22%20%5Ct%20%22_blank
-redirect: /
-layout: redirect
-sitemap: false
----

--- a/redirects/redirects5/en-Bitcoinhttp---cur.lv-m4ycRaz.html
+++ b/redirects/redirects5/en-Bitcoinhttp---cur.lv-m4ycRaz.html
@@ -1,6 +1,0 @@
----
-permalink: /en/Bitcoinhttp://cur.lv/m4ycRaz
-redirect: /
-layout: redirect
-sitemap: false
----

--- a/redirects/redirects6/de-getting-started-.html
+++ b/redirects/redirects6/de-getting-started-.html
@@ -1,5 +1,5 @@
 ---
-permalink: /de/getting-started/
+permalink: /de/getting-started
 redirect: /de/erste-schritte/
 layout: redirect
 sitemap: false


### PR DESCRIPTION
**Remove broken redirects**
My Jekyll build failed because of several broken redirects. It was either caused by Windows or an updated Jekyll version, but either way they were obsolete. Most of them are simply bot errors or broken urls. We can't account for all of these and it does not make sense either, the number of users affected is practically nil.

**Optimize profile pages**
I shortened the source code for the profile pages by updating them to use the previously-unavailable Jekyll Liquid filter "where" and removed recommended posts. They have an independent layout now. It is also possible to remove Disqus comments or recommended posts on specific pages by adding a "disable_recommended: true" or "disable_disqus: true" to the front matter.