### PR TITLE
Clean up people and companies

### DIFF
--- a/_companies/21.md
+++ b/_companies/21.md
@@ -4,15 +4,15 @@ seotitle: 21 - Creator of the 21 Bitcoin Computer
 img: /images/company/21.png
 cats: featured
 ---
-[21 Inc](https://21.co/) is the creator of the 21 Bitcoin Computer. 
+[21 Inc](https://21.co/) is the creator of the 21 Bitcoin Computer.
 
 ## 21 Bitcoin Computer
 
-21 Inc believes that satoshis--the smallest unit of BTC--will become a system resource used to pay for small tasks across the internet. One project built using the 21's computer, for example, uses the company's software to [sell API calls](https://github.com/joepickrell/genome-server-21) for satoshis. [Another](https://github.com/justinguy/21-retweet) allows Twitter accounts to sell retweets for satoshis. 
+21 Inc believes that satoshis--the smallest unit of BTC--will become a system resource used to pay for small tasks across the internet. One project built using the 21's computer, for example, uses the company's software to [sell API calls](https://github.com/joepickrell/genome-server-21) for satoshis. [Another](https://github.com/justinguy/21-retweet) allows Twitter accounts to sell retweets for satoshis.
 
-The 21 Bitcoin Computer is a computer that comes with a 50 Gh/s mining chip and also operates as a Bitcoin full node. The built-in mining chip provides the computer's owner with a constant stream of satoshis that can be used to pay for these small tasks. 
-   
-The 21 Bitcoin Computer is available on [Amazon](http://www.amazon.com/21-INC-21BC1-Bitcoin-Computer/dp/B014RD021C) or from the [company's website](https://21.co/buy/) and costs $399. 
+The 21 Bitcoin Computer is a computer that comes with a 50 Gh/s mining chip and also operates as a Bitcoin full node. The built-in mining chip provides the computer's owner with a constant stream of satoshis that can be used to pay for these small tasks.
+
+The 21 Bitcoin Computer is available on [Amazon](http://www.amazon.com/21-INC-21BC1-Bitcoin-Computer/dp/B014RD021C) or from the [company's website](https://21.co/buy/) and costs $399.
 
 ## Documentation
 
@@ -21,7 +21,7 @@ The 21 Bitcoin Computer is available on [Amazon](http://www.amazon.com/21-INC-21
 ## Venture Capital Rounds
 
 {% for company in site.data.companies %}
-{% if company.company == '21 Inc (21e6)' %}
-{% include company_list.html %}
-{% endif %}
+  {% if company.company == '21 Inc (21e6)' %}
+    {% include company_list.html %}
+  {% endif %}
 {% endfor %}

--- a/_companies/airbitz.md
+++ b/_companies/airbitz.md
@@ -1,9 +1,6 @@
 ---
 title: Airbitz
 seotitle: Airbitz Bitcoin Wallet - About Page
-author: Airbitz
-authorurl: https://www.weusecoins.com/airbitz/
-published: true
 cats: featured
 img: /images/airbitz.png
 ---
@@ -111,7 +108,7 @@ Tim has no turned his interested to all things crypto. When he isn't hashing and
 <h2>Venture Capital Rounds</h2>
 
 {% for company in site.data.companies %}
-{% if company.company == 'Airbitz' %}
-{% include company_list.html %}
-{% endif %}
+  {% if company.company == 'Airbitz' %}
+    {% include company_list.html %}
+  {% endif %}
 {% endfor %}

--- a/_companies/alphapoint.md
+++ b/_companies/alphapoint.md
@@ -1,8 +1,6 @@
 ---
-title: Alphapoint About Page
-author: Alphapoint
-authorurl: http://www.weusecoins.com
-published: true
+title: Alphapoint
+seotitle: Alphapoint About Page
 ---
 
 This is an early about page for Alphapoint.

--- a/_companies/anx.md
+++ b/_companies/anx.md
@@ -1,8 +1,6 @@
 ---
-title: ANX About Page
-author: ANX
-authorurl: http://www.weusecoins.com
-published: true
+title: ANX
+seotitle: ANX About Page
 ---
 
 This is an early about page for ANX.

--- a/_companies/anycoin.md
+++ b/_companies/anycoin.md
@@ -1,8 +1,6 @@
 ---
-title: Anycoin Direct - About Page
-author: Anycoin Direct
-authorurl: https://www.weusecoins.com/anycoin/
-published: true
+title: Anycoin
+seotitle: Anycoin Direct - About Page
 ---
 
 <img src="/images/anycoin.png" alt="Anycoin Direct" align="center">

--- a/_companies/armory.md
+++ b/_companies/armory.md
@@ -1,8 +1,6 @@
 ---
-title: Armory - About Page
-author: Armory
-authorurl: https://www.weusecoins.com/armory/
-published: true
+title: Armory
+seotitle: Armory - About Page
 ---
 
 <img src="/images/armory.png" alt="Armory" align="center">

--- a/_companies/bar-kayma.md
+++ b/_companies/bar-kayma.md
@@ -1,8 +1,5 @@
 ---
 title: Bar Kayma
-author: Bar Kayma
-authorurl: /bar-kayma/
-published: true
 ---
 
 <p>The Bar Kayma is a sustainable vegan restaurant and bar owned by the cooperative, proud to have about 450 members so far (a number that increases daily…) with a rich and healthy menu and many interesting activities taking place on a daily and weekly basis.
@@ -21,7 +18,7 @@ published: true
 <p>Bar Kayma provides advice and support to uprising cooperatives country wide!
 <p>~~~~~
 <h3>The Restaurant & Bar:</h3>
-<p>The first cooperative decision was to serve vegan food. We found it obvious that the food we offer should be considerate- towards our environment and to all living creatures of this world. 
+<p>The first cooperative decision was to serve vegan food. We found it obvious that the food we offer should be considerate- towards our environment and to all living creatures of this world.
 <p>Another step in the way to considerate nutrition was the decision not to support industries such as mineral water and Coca kola. Instead, on the  beverages side - we offer freshly squeezed juices, unique, tasty and healthy smoothies, etc. If you haven't tasted the Halve Shake yet – you're loosing out!
 <p>Most of our food and is not processed in a factory. The sauces, vegan cheeses and even the ketchup as well as our - are all freshly made in our kitchen!
 <h3>The Store:</h3>

--- a/_companies/bitcoin-core.md
+++ b/_companies/bitcoin-core.md
@@ -1,10 +1,9 @@
 ---
 title: Bitcoin Core
-published: true
 cats:
  - ww
 ---
-Bitcoin Core--formerly Bitcoin-Qt--is a Bitcoin codebase based on the original code and framework published by Satoshi Nakamoto. Bitcoin Core is currently run by more than 70% of Bitcoin nodes and all miners. 
+Bitcoin Core--formerly Bitcoin-Qt--is a Bitcoin codebase based on the original code and framework published by Satoshi Nakamoto. Bitcoin Core is currently run by more than 70% of Bitcoin nodes and all miners.
 
 ## Purpose & Goals
 
@@ -21,34 +20,28 @@ Bitcoin Core is open source and [hosted on GitHub](https://github.com/bitcoin/bi
 
 ### Developers
 
-Wladimir van der Laan is the Lead Maintainer of Bitcoin Core. He has direct commit access to the Core Github repo and is responsible for merging pull requests, moderation, and the release cycle. 
+Wladimir van der Laan is the Lead Maintainer of Bitcoin Core. He has direct commit access to the Core Github repo and is responsible for merging pull requests, moderation, and the release cycle.
 
-[More than 350 developers](https://github.com/bitcoin/bitcoin/graphs/contributors) have contributed to the project. 
+[More than 350 developers](https://github.com/bitcoin/bitcoin/graphs/contributors) have contributed to the project.
 
-The profiles of the most active developers are listed below: 
+The profiles of the most active developers are listed below:
 
-<div class="similar-people-wrap">
-{% for person in site.people %}
-{% if person.affiliations contains 'Bitcoin Core' %}
-{% include similar-people.html %}
-{% endif %}
-{% endfor %}
-</div>
+{% include similar-people.html organization="Bitcoin Core" %}
 
 ## BIPs
 
-New feature proposals for Bitcoin Core are submitted as Bitcoin Improvement Proposals (BIPs). BIPs are [hosted on GitHub](https://github.com/bitcoin/bips/) and maintained by Bitcoin Core developer Luke Dashjr. 
+New feature proposals for Bitcoin Core are submitted as Bitcoin Improvement Proposals (BIPs). BIPs are [hosted on GitHub](https://github.com/bitcoin/bips/) and maintained by Bitcoin Core developer Luke Dashjr.
 
-[BIP 1](https://github.com/bitcoin/bips/blob/master/bip-0001.mediawiki) outlines BIP guidelines, rules, formatting, and workflow. 
+[BIP 1](https://github.com/bitcoin/bips/blob/master/bip-0001.mediawiki) outlines BIP guidelines, rules, formatting, and workflow.
 
 ## Download
 
-Bitcoin Core is available for download from [bitcoin.org](https://bitcoin.org/en/download). The latest version is 0.12. 
+Bitcoin Core is available for download from [bitcoin.org](https://bitcoin.org/en/download). The latest version is 0.12.
 
 ## Controversy
 
-Bitcoin stands to uproot, alter, or damage existing financial institutions, governments, payment networks, and currencies. Like with any groundbreaking technology, not every user agrees on how/which features should be implemented, or who should control the protocol. 
+Bitcoin stands to uproot, alter, or damage existing financial institutions, governments, payment networks, and currencies. Like with any groundbreaking technology, not every user agrees on how/which features should be implemented, or who should control the protocol.
 
 Bitcoin's block size debate brought Bitcoin Core into the spotlight. Many claim that the Core development team should raise the block size from 1 MB to add more space for on-chain Bitcoin transactions. The Bitcoin Core team prefers to address scaling with protocols built on top of Bitcoin, like [Lightning Network](/adam-back-lightning-network/) and [sidechains](/what-are-sidechains/).  
 
-Alternate implementations like the failed [Classic and XT](https://bitcoinmagazine.com/articles/unlimited-classic-and-bitpay-core-bitcoin-s-new-kids-on-the-blockchain-1452705977) projects led by [Gavin Andresen](/gavin-andresen/) attempted to dangerously hard fork the Bitcoin network away from Bitcoin Core but ultimately died out after failing to reach consensus among miners, exchanges, developers, businesses and users. 
+Alternate implementations like the failed [Classic and XT](https://bitcoinmagazine.com/articles/unlimited-classic-and-bitpay-core-bitcoin-s-new-kids-on-the-blockchain-1452705977) projects led by [Gavin Andresen](/gavin-andresen/) attempted to dangerously hard fork the Bitcoin network away from Bitcoin Core but ultimately died out after failing to reach consensus among miners, exchanges, developers, businesses and users.

--- a/_companies/bitfury.md
+++ b/_companies/bitfury.md
@@ -1,6 +1,5 @@
 ---
 title: BitFury
-seotitle: BitFury
 img: /images/company/bitfury.jpg
 cats: featured
 ---
@@ -12,9 +11,9 @@ BitFury runs some of the largest private mining operations in the world. Its min
 
 ## BitFury Capital
 
-On top of its Bitcoin mining operations, BitFury operates [BitFury Capital](http://bitfurycapital.com/), where it "supports the growth of the Bitcoin ecosystem through strategic partnerships and business opportunities." 
+On top of its Bitcoin mining operations, BitFury operates [BitFury Capital](http://bitfurycapital.com/), where it "supports the growth of the Bitcoin ecosystem through strategic partnerships and business opportunities."
 
-BitFury Capital has invested in Xapo, BitGo, and GoCoin. 
+BitFury Capital has invested in Xapo, BitGo, and GoCoin.
 
 ## 16nm ASIC Mining Chip
 

--- a/_companies/bitinstant.md
+++ b/_companies/bitinstant.md
@@ -1,8 +1,5 @@
 ---
 title: BitInstant
-author: BitInstant
-authorurl: /bitinstant/
-published: true
 ---
 
 This is a page about BitInstant.

--- a/_companies/bitit.md
+++ b/_companies/bitit.md
@@ -1,14 +1,11 @@
 ---
-layout: post
-title: Bitit | Buy Bitcoins fast and easy
-author: Bitit
-authorurl: https://www.bitit.gift
+title: Bitit
+seotitle: Bitit | Buy Bitcoins fast and easy
 description: Buy Bitcoins online by credit card and by cash in 100K+ Local stores.
-published: true
 ---
 <p style="margin-bottom: 20px;"><a class="social-link" href="https://twitter.com/bitit_gift" class="twitter-follow-button" data-show-count="false" data-size="large">Follow @Bitit</a></p>
 
-<p>Bitit lets users buy Bitcoin through its prepaid vouchers and Bitcoin gift cards. 
+<p>Bitit lets users buy Bitcoin through its prepaid vouchers and Bitcoin gift cards.
 <p>These tools make it very easy to buy your first bitcoins.
 <p>By credit card or by cash in more than 100K+ Local stores choose your most convenient way to buy Bitcoin.
 <p>Bitit is the easiest way to buy, send & receive Bitcoins.<br><br></p>
@@ -42,7 +39,7 @@ published: true
 </ul>
 <hr/>
 ### Supported Countries
-<p>Available in the United States, Canada, and most of Europe.</p> 
+<p>Available in the United States, Canada, and most of Europe.</p>
 <p>All European and Canadian residents may <a title="Bitit" href="https://www.bitit.gift/physical" target="_blank" style="text-decoration:none; color:#FF693A;">buy bitcoin by cash with Neosurf</a></p>
 <hr/>
 ### Privacy & Limits

--- a/_companies/blockstream.md
+++ b/_companies/blockstream.md
@@ -1,15 +1,14 @@
 ---
 title: Blockstream
-seotitle: Blockstream
 img: /images/company/blockstream.png
 ---
-Blockstream is one of the most-well funded Bitcoin companies, with $76 million in [venture capital](/en/venture-capital-investments-in-bitcoin-and-blockchain-companies/) thanks to its [latest $55 million funding round](https://blockstream.com/2016/02/02/blockstream-new-investors-55-million-series-a/). 
+Blockstream is one of the most-well funded Bitcoin companies, with $76 million in [venture capital](/en/venture-capital-investments-in-bitcoin-and-blockchain-companies/) thanks to its [latest $55 million funding round](https://blockstream.com/2016/02/02/blockstream-new-investors-55-million-series-a/).
 
 ## Sidechains
 
-Blockstream has yet to fully unveil or explain all of its company's products. It's website, however, explains that "Block­stream’s core area of in­no­va­tion is sidechains, a tech­nol­ogy fo­cused on im­prov­ing on the blockchain, the most pow­er­ful pub­lic util­ity for dis­trib­uted trust sys­tems." 
+Blockstream has yet to fully unveil or explain all of its company's products. It's website, however, explains that "Block­stream’s core area of in­no­va­tion is sidechains, a tech­nol­ogy fo­cused on im­prov­ing on the blockchain, the most pow­er­ful pub­lic util­ity for dis­trib­uted trust sys­tems."
 
-It appears that Blockstream is taking a different approach to blockchains. Instead of creating separate private blockchains or altcoins, Blockstream will create sidechains that allow for somewhat _private_ blockchains that are built on top of Bitcoin. 
+It appears that Blockstream is taking a different approach to blockchains. Instead of creating separate private blockchains or altcoins, Blockstream will create sidechains that allow for somewhat _private_ blockchains that are built on top of Bitcoin.
 
 According to its websites, sidechains offer many advantages over blockchains separate from Bitcoin because they avoid "liq­uid­ity short­ages, mar­ket fluc­tu­a­tions, frag­men­ta­tion, se­cu­rity breaches and out­right fraud as­so­ci­ated with al­ter­na­tive crypto-cur­ren­cies."
 
@@ -19,19 +18,13 @@ On October 12, 2015, Blockstream [announced the release](https://blockstream.com
 
 ## Lightning Network
 
-Blockstream hired Rusty Russell, a [well-known developer](https://en.wikipedia.org/wiki/Rusty_Russell) famous for his work on Linux kernel, to develop an implementation of the Bitcoin Lightning Network (LN). Russell has a [four-part LN explanation on his blog](http://rusty.ozlabs.org/?p=450). 
+Blockstream hired Rusty Russell, a [well-known developer](https://en.wikipedia.org/wiki/Rusty_Russell) famous for his work on Linux kernel, to develop an implementation of the Bitcoin Lightning Network (LN). Russell has a [four-part LN explanation on his blog](http://rusty.ozlabs.org/?p=450).
 
 ## Employees
 
-Blockstream employs many of the most prominent and active [Bitcoin Core](/bitcoin-core/) developers. 
+Blockstream employs many of the most prominent and active [Bitcoin Core](/bitcoin-core/) developers.
 
-<div class="similar-people-wrap">
-{% for person in site.people %}
-{% if person.affiliations contains 'Blockstream' %}
-{% include similar-people.html %}
-{% endif %}
-{% endfor %}
-</div>
+{% include similar-people.html organization="Blockstream" %}
 
 ## Venture Capital Rounds
 
@@ -43,6 +36,6 @@ Blockstream employs many of the most prominent and active [Bitcoin Core](/bitcoi
 
 ## Controversy
 
-Bitcoin's block size debate has caused some to question the company's incentives. Blockstream employs five developers who have contributed to or contribute to Bitcoin Core: Pieter Wuille, Jorge Timón, Gregory Maxwell, Mark Friedenbach, and Matt Corallo. 
+Bitcoin's block size debate has caused some to question the company's incentives. Blockstream employs five developers who have contributed to or contribute to Bitcoin Core: Pieter Wuille, Jorge Timón, Gregory Maxwell, Mark Friedenbach, and Matt Corallo.
 
-Some claim that Blockstream intends to control the Bitcoin protocol through its employment of Bitcoin Core developers. This, however, seems unlikely. Bitcoin Core's lead maintainer is part of MIT’s Digital Currency Initiative and only merges pull requests with far-reaching consensus, regardless of what any of Blockstream's employees may request or suggest. 
+Some claim that Blockstream intends to control the Bitcoin protocol through its employment of Bitcoin Core developers. This, however, seems unlikely. Bitcoin Core's lead maintainer is part of MIT’s Digital Currency Initiative and only merges pull requests with far-reaching consensus, regardless of what any of Blockstream's employees may request or suggest.

--- a/_companies/blocktrail.md
+++ b/_companies/blocktrail.md
@@ -1,8 +1,5 @@
 ---
 title: BlockTrail
-author: Boaz Bechar
-authorurl: https://www.weusecoins.com/boaz-bechar/
-published: true
 cats: featured
 img: /images/blocktrail.png
 ---

--- a/_companies/breadwallet.md
+++ b/_companies/breadwallet.md
@@ -1,9 +1,6 @@
 ---
 title: Breadwallet
 seotitle: Breadwallet About Page
-author: Breadwallet
-authorurl: http://www.weusecoins.com
-published: true
 cats: featured
 img: /images/breadwallet.jpg
 ---

--- a/_companies/bytecoin.md
+++ b/_companies/bytecoin.md
@@ -1,8 +1,5 @@
 ---
 title: Bytecoin
-author: We Use Coins
-authorurl: /
-published: true
 ---
 
 <p>Bytecoin is the private untraceable cryptocurrency launched in 2012 and is the first enterprise-ready solution.

--- a/_companies/coincorner.md
+++ b/_companies/coincorner.md
@@ -1,5 +1,6 @@
 ---
-title: CoinCorner - About Page
+title: CoinCorner
+seotitle: CoinCorner - About Page
 author: CoinCorner Liam
 authorurl: https://www.weusecoins.com/coincorner/
 published: true

--- a/_companies/coinkite.md
+++ b/_companies/coinkite.md
@@ -1,9 +1,6 @@
 ---
 title: Coinkite
 seotitle: Coinkite Bitcoin Wallet and Platform - About Page
-author: Coinkite
-authorurl: https://www.weusecoins.com/coinkite/
-published: true
 cats: featured
 img: /images/coinkite.png
 ---
@@ -19,7 +16,7 @@ and completely avoid human error in daily operations.
 
 <p>
   <ul>
-	<li><a href="https://coinkite.com/multisig">Bitcoin Multi-Signature</a> and <a href="https://coinkite.com/security">Hot Wallets</a></li> 
+	<li><a href="https://coinkite.com/multisig">Bitcoin Multi-Signature</a> and <a href="https://coinkite.com/security">Hot Wallets</a></li>
     <li><a href="https://coinkite.com/merchants">Merchant Tools</a> (i.e.<a href="https://coinkite.com/faq/pay">Pay Buttons</a>)</li>
     <li><a href="https://coinkite.com/startups">Startup and Business Platform</a></li>
     <li><a href="https://coinkite.com/developers">Developer's API Platform</a></li>
@@ -63,4 +60,3 @@ who still codes everyday.
     <li>Bitcoin Core Developer</li>
   </ul>
 </p>
-

--- a/_companies/cryptohippie.md
+++ b/_companies/cryptohippie.md
@@ -1,18 +1,17 @@
 ---
-title: About Cryptohippie
-author: Paul Rosenberg
-authorurl: https://www.weusecoins.com/paul-rosenberg/
+title: Cryptohippie
+seotitle: About Cryptohippie
 ---
-Cryptohippie, Inc. is a market leading provider of professional-level <a href="/bitcoin-vpns/">VPN protection</a>. 
+Cryptohippie, Inc. is a market leading provider of professional-level <a href="/bitcoin-vpns/">VPN protection</a>.
 
-Cryptohippie (a suite of companies) was formed in 2007 through the acquisition of MeshMX, Diclave, and Roque Holdings - all of which were little-known but highly regarded providers of superior privacy enhancing technologies. We were the first to provide VPN-based privacy protection services to the market, beginning in early 2003. Cryptohippie's management and development teams are composed of seasoned professionals with long experience both in running enterprise-grade secure networks and operating businesses in the privacy market. 
+Cryptohippie (a suite of companies) was formed in 2007 through the acquisition of MeshMX, Diclave, and Roque Holdings - all of which were little-known but highly regarded providers of superior privacy enhancing technologies. We were the first to provide VPN-based privacy protection services to the market, beginning in early 2003. Cryptohippie's management and development teams are composed of seasoned professionals with long experience both in running enterprise-grade secure networks and operating businesses in the privacy market.
 
 ### Mission
 
-Cryptohippie’s mission is to protect individuality and privacy on the Internet – to prevent all transgressions against privacy, from whatever source. This is much more than pretty talk for us. Every person on our management team has a successful professional life outside of Cryptohippie. We do not have to do this – we do it because it matters. 
+Cryptohippie’s mission is to protect individuality and privacy on the Internet – to prevent all transgressions against privacy, from whatever source. This is much more than pretty talk for us. Every person on our management team has a successful professional life outside of Cryptohippie. We do not have to do this – we do it because it matters.
 
 ### Philosophy
 
-We believe that human beings should live by reason, as individuals, with integrity, and with passion. Privacy allows that. Furthermore, we demand of our clients what we demand of ourselves: To demonstrate honesty and to show respect for the dignity of man, privacy, and for sound economic principles. All others need not apply. 
+We believe that human beings should live by reason, as individuals, with integrity, and with passion. Privacy allows that. Furthermore, we demand of our clients what we demand of ourselves: To demonstrate honesty and to show respect for the dignity of man, privacy, and for sound economic principles. All others need not apply.
 
 Cryptohippie  has offered all We Use Coins readers a <a href="https://secure.cryptohippie.com/weusecoins.php">free trial</a> of their privacy service

--- a/_companies/cryptolabs.md
+++ b/_companies/cryptolabs.md
@@ -1,8 +1,6 @@
 ---
-title: Cryptolabs About Page
-author: Cryptolabs
-authorurl: http://www.weusecoins.com
-published: true
+title: Cryptolabs
+seotitle: Cryptolabs About Page
 ---
 
 This is an early about page for Cryptolabs.

--- a/_companies/factom.md
+++ b/_companies/factom.md
@@ -1,8 +1,6 @@
 ---
+title: Factom
 title: Factom About Page
-author: Nicola Minichiello
-authorurl: https://www.weusecoins.com/nicola-minichiello
-published: true
 ---
 
 <img src="/images/factom_logo.png" alt="Factom Logo">

--- a/_companies/kraken-bitcoin-exchange.md
+++ b/_companies/kraken-bitcoin-exchange.md
@@ -1,17 +1,15 @@
 ---
-title: Kraken About Page
-author: Kraken - Bitcoin Exchange
-authorurl: http://www.weusecoins.com/kraken-bitcoin-exchange/
-published: true
+title: Kraken
+seotitle: Kraken About Page
 img: /images/company/kraken.png
 ---
-[Kraken](https://www.kraken.com) is the [best Bitcoin exchange](/en/how-buy-bitcoins-online-best-bitcoin-exchange-rate-bitcoin-price/) for converting to and from US dollars, euros, British pounds and Japanese yen. Founded in 2011, San Francisco based Kraken is consistently rated the top Bitcoin exchange by [independent news media](/images/cointelegraph-best-bitcoin-exchange.jpg) and was the first Bitcoin exchange listed on [Bloomberg terminals](http://blog.kraken.com/post/111931691762/kraken-listed-on-bloomberg). 
+[Kraken](https://www.kraken.com) is the [best Bitcoin exchange](/en/how-buy-bitcoins-online-best-bitcoin-exchange-rate-bitcoin-price/) for converting to and from US dollars, euros, British pounds and Japanese yen. Founded in 2011, San Francisco based Kraken is consistently rated the top Bitcoin exchange by [independent news media](/images/cointelegraph-best-bitcoin-exchange.jpg) and was the first Bitcoin exchange listed on [Bloomberg terminals](http://blog.kraken.com/post/111931691762/kraken-listed-on-bloomberg).
 
 Kraken is trusted by hundreds of thousands of traders, the Tokyo government and [court-appointed trustee](https://bitcoinmagazine.com/20030/kraken-accepting-mtgox-bankruptcy-claims-and-giving-free-trade-credit/), and BaFin regulated [exclusive partnership](/images/2014-10-31-worlds-first-crypto-currency-bank-fidor-bank-ag-and-kraken-welcome-potential-partners-in-establishing-banking-platform.pdf) and full regulatory compliance.
 
 ## Acquisition of Coinsetter & Cavirtex
 
-In January 2016, Kraken [acquired](http://www.coindesk.com/bitcoin-kraken-coinsetter-acquired/) U.S. Bitcoin exchange Coinsetter and Canadian Bitcoin exchange Cavirtex. After establishing itself as the world leader in EUR/BTC trading, its acquisition of Coinsetter will enable Kraken to expand its reach to the U.S. and Canadian markets. 
+In January 2016, Kraken [acquired](http://www.coindesk.com/bitcoin-kraken-coinsetter-acquired/) U.S. Bitcoin exchange Coinsetter and Canadian Bitcoin exchange Cavirtex. After establishing itself as the world leader in EUR/BTC trading, its acquisition of Coinsetter will enable Kraken to expand its reach to the U.S. and Canadian markets.
 
 ## Venture Capital Rounds
 

--- a/_companies/ledger.md
+++ b/_companies/ledger.md
@@ -3,11 +3,11 @@ title: Ledger
 seotitle: Ledger - Trusted Bitcoin Hardware Solutions
 img: /images/company/ledger.png
 ---
-[Ledger](https://www.ledger.co/) is a Bitcoin security company known for its Bitcoin hardware wallets. 
+[Ledger](https://www.ledger.co/) is a Bitcoin security company known for its Bitcoin hardware wallets.
 
 ## Products
 
-Ledger currently offers three Bitcoin hardware wallets: the Ledger Nano, Ledger HW.1, and Ledger Unplugged. 
+Ledger currently offers three Bitcoin hardware wallets: the Ledger Nano, Ledger HW.1, and Ledger Unplugged.
 
 ### Ledger Nano
 
@@ -19,23 +19,23 @@ The [Ledger Nano](https://www.weusecoins.com/bitcoin-ledger-wallet-review/) is L
 
 ![ledger][3]{: .ledger-profile}
 
-The Ledger HW.1 is similar to the Ledger Nano and built upon the same CC EAL5+ smartcard. The HW.1, however, lacks the Nano's sleek design and metal build. Ledger calls the HW.1 an "enterprise solution for multi-signature". It is a cheap, secure way for companies or groups to securely share control of bitcoins. 
+The Ledger HW.1 is similar to the Ledger Nano and built upon the same CC EAL5+ smartcard. The HW.1, however, lacks the Nano's sleek design and metal build. Ledger calls the HW.1 an "enterprise solution for multi-signature". It is a cheap, secure way for companies or groups to securely share control of bitcoins.
 
 ### Ledger Unplugged
 
 ![ledger][2]{: .ledger-profile}
 
-The Ledger Unplugged is a Java Card, NFC Bitcoin wallet. It provides extra security for mobile wallets. The Unplugged is compatible with Android phones using Mycelium or GreenAddress. 
+The Ledger Unplugged is a Java Card, NFC Bitcoin wallet. It provides extra security for mobile wallets. The Unplugged is compatible with Android phones using Mycelium or GreenAddress.
 
 ## Applications
 
 ### Chrome Extension
 
-The [Ledger Chrome Extension](https://chrome.google.com/webstore/detail/ledger-wallet/kkdpmhnladdopljabkgpacgpliggeeaf) is used to setup the Ledger Nano and HW.1. Once setup, the Chrome Extension serves as a software wallet and is used to send and receive bitcoins with either wallet. 
+The [Ledger Chrome Extension](https://chrome.google.com/webstore/detail/ledger-wallet/kkdpmhnladdopljabkgpacgpliggeeaf) is used to setup the Ledger Nano and HW.1. Once setup, the Chrome Extension serves as a software wallet and is used to send and receive bitcoins with either wallet.
 
 ### Android & iPhone Apps
 
-The [Ledger](https://www.coldhardware.com/ledger-nano-review/) [Android](https://play.google.com/store/apps/details?id=co.ledger.wallet) and [iPhone](https://itunes.apple.com/WebObjects/MZStore.woa/wa/viewSoftware?id=960196441&mt=8) apps are used to provide 2-factor authentication for outgoing transactions. While each Ledger device comes with its own 2-factor security card, the iPhone and Android apps can also be used as a more convenient form of 2-factor authentication. 
+The [Ledger](https://www.coldhardware.com/ledger-nano-review/) [Android](https://play.google.com/store/apps/details?id=co.ledger.wallet) and [iPhone](https://itunes.apple.com/WebObjects/MZStore.woa/wa/viewSoftware?id=960196441&mt=8) apps are used to provide 2-factor authentication for outgoing transactions. While each Ledger device comes with its own 2-factor security card, the iPhone and Android apps can also be used as a more convenient form of 2-factor authentication.
 
 ## Future Plans
 
@@ -43,13 +43,7 @@ Ledger plans to release its fourth device, the Ledger Blue, in mid-2016.
 
 ## Employees
 
-<div class="similar-people-wrap">
-{% for person in site.people %}
-{% if person.affiliations contains 'Ledger' %}
-{% include similar-people.html %}
-{% endif %}
-{% endfor %}
-</div>
+{% include similar-people.html organization="Ledger" %}
 
 ## Venture Capital Rounds
 

--- a/_companies/openbazaar.md
+++ b/_companies/openbazaar.md
@@ -29,13 +29,7 @@ OpenBazaar offers both buyers and sellers many advantages over traditional onlin
 
 ## OpenBazaar Developers
 
-<div class="similar-people-wrap">
-{% for person in site.people %}
-{% if person.affiliations contains 'OpenBazaar' %}
-{% include similar-people.html %}
-{% endif %}
-{% endfor %}
-</div>
+{% include similar-people.html organization="OpenBazaar" %}
 
 ## Links
 

--- a/_companies/paxful.md
+++ b/_companies/paxful.md
@@ -1,8 +1,6 @@
 ---
-title: Paxful About Page
-author: Paxful
-authorurl: /paxful/
-published: true
+title: Paxful
+seotitle: Paxful About Page
 ---
 
 Paxul has been integrated with Backpage and there is this helpful guide: <a href="/how-to-use-bitcoin-with-backpage/">How To Use Bitcoin With Backpage</a>.

--- a/_companies/safello.md
+++ b/_companies/safello.md
@@ -1,8 +1,6 @@
 ---
-title: Safello About Page
-author: Safello
-authorurl: http://www.weusecoins.com
-published: true
+title: Safello
+seotitle: Safello About Page
 ---
 
 This is an early about page for Safello an European Bitcoin exchange.

--- a/_companies/shapeshift.md
+++ b/_companies/shapeshift.md
@@ -1,21 +1,18 @@
 ---
-title: Shapeshift About Page
-author: Shapeshift
-authorurl: http://www.weusecoins.com
-published: true
-img: /images/company/shapeshift.png
+title: Shapeshift
+seotitle: Shapeshift About Page
 ---
-ShapeShift is a digital asset exchange. Unlike regular cryptocurrency exchanges, ShapeShift does not need personal information because no account creation is required. 
+ShapeShift is a digital asset exchange. Unlike regular cryptocurrency exchanges, ShapeShift does not need personal information because no account creation is required.
 
 ## How ShapeShift Works
 
 ShapeShift makes it easy to exchange cryptocurrencies. First, users select their deposit currency from a list. Next, the user selects which currency to receive in the exchange. An address is then displayed on the screen. Once the user sends the required amount of the deposit currency to the address, the exchange takes places and the requested cryptocurrency is sent to the user's receiving address.  
 
-While ShapeShift is currently used for Bitcoin and altcoin exchanges, its model could be used in the future for stocks, titles, and more once greater amounts of assets become digital. 
+While ShapeShift is currently used for Bitcoin and altcoin exchanges, its model could be used in the future for stocks, titles, and more once greater amounts of assets become digital.
 
 ## History
 
-ShapeShift.io was founded by [Erik Voorhees](/erik-voorhees/) in August 2014. Throughout the company's first few months, Voorhees kept his involvement with the company a secret in order to prove its ability to trustlessly exchange digital assets. 
+ShapeShift.io was founded by [Erik Voorhees](/erik-voorhees/) in August 2014. Throughout the company's first few months, Voorhees kept his involvement with the company a secret in order to prove its ability to trustlessly exchange digital assets.
 
 ## Venture Capital Rounds
 

--- a/_companies/the-merkle.md
+++ b/_companies/the-merkle.md
@@ -1,8 +1,6 @@
 ---
-title: The Merkle About Page
-author: The Merkle
-authorurl: http://www.weusecoins.com
-published: true
+title: The Merkle
+seotitle: The Merkle About Page
 ---
 
 This is for The Merkle.

--- a/_companies/tradehill.md
+++ b/_companies/tradehill.md
@@ -1,8 +1,5 @@
 ---
 title: Tradehill
-author: Tradehill
-authorurl: /tradehill/
-published: true
 ---
 
 This is a page about Tradehill.

--- a/_includes/person.html
+++ b/_includes/person.html
@@ -1,0 +1,8 @@
+<div class="person-display">
+
+<a href="{{ person.url }}"><img src="{{ person.img }}"></a>
+<a href="{{ person.url }}"><div class="name">{{ person.title }}</div></a>
+
+<div class="position">{{ person.position }}</div>
+
+</div>

--- a/_includes/similar-people.html
+++ b/_includes/similar-people.html
@@ -1,8 +1,7 @@
-<div class="similar-people">
-
-<a href="{{ person.url }}"><img src="{{ person.img }}"></a>
-<a href="{{ person.url }}"><div class="name">{{ person.name }}</div></a>
-
-<div class="position">{{ person.position }}</div>
-
+<div class="person-list">
+{% for person in site.people %}
+  {% if person.affiliations contains include.organization and person.title != include.name %}
+    {% include person.html %}
+  {% endif %}
+{% endfor %}
 </div>

--- a/_people/aaron-voisine-bitcoin-security-expert.md
+++ b/_people/aaron-voisine-bitcoin-security-expert.md
@@ -1,30 +1,27 @@
 ---
 title: Aaron Voisine
-author: Aaron Voisine
 seotitle: Aaron Voisine - Bitcoin Security Expert
-authorurl: https://www.weusecoins.com/aaron-voisine-bitcoin-security-expert
-published: true
 img: /images/aaron-voisine.png
-name: Aaron Voisine
 position: CEO, breadwallet
 education: B.S. in Computer Science from Purdue University
-experience: 
+experience:
 short_desc: Aaron Voisine is the CEO and Founder of breadwallet.
-long_desc: 
-affiliations: breadwallet
-twitter: 
+long_desc:
+affiliations:
+  - breadwallet
+twitter:
 github: voisine
-residence: 
+residence:
 ---
-Aaron Voisine is the CEO and Founder of <a href="/breadwallet/">Breadwallet</a>. 
+Aaron Voisine is the CEO and Founder of <a href="/breadwallet/">Breadwallet</a>.
 
 ## breadwallet
 
 Voisine founded [breadwallet](http://breadwallet.com/) in 2014. It is an [open source](https://github.com/voisine/breadwallet) SVP wallet for iOS and one of the most [popular Bitcoin wallets](/en/find-the-best-bitcoin-wallet/).
 
-## Passphrase-protected private key (BIP 38) 
+## Passphrase-protected private key (BIP 38)
 
-Voisine contributed code to [BIP 38](https://github.com/bitcoin/bips/blob/master/bip-0038.mediawiki), which added passphrase-protected private keys to Bitcoin. An additional layer of protection for paper wallets was needed in order to prevent against physical theft. 
+Voisine contributed code to [BIP 38](https://github.com/bitcoin/bips/blob/master/bip-0038.mediawiki), which added passphrase-protected private keys to Bitcoin. An additional layer of protection for paper wallets was needed in order to prevent against physical theft.
 
 ## History
 

--- a/_people/adrian-childers.md
+++ b/_people/adrian-childers.md
@@ -1,10 +1,8 @@
 ---
-title: Adrian Childers - Bitcoin Enthusiast
-author: Adrian Childers
-authorurl: http://www.adrianchilders.com
-published: true
+title: Adrian Childers
+seotitle: Adrian Childers - Bitcoin Enthusiast
 ---
 
-Adrian Childers is a bitcoin enthusiast and fan of all things open source, decentralized and person to person. He is originally from Texas but spends most of his time in Miami Beach now. Since discovering bitcoin in 2012 he has promoted it to anyone that will listen and is frequently seen at bitcoin meetups in South Florida. 
+Adrian Childers is a bitcoin enthusiast and fan of all things open source, decentralized and person to person. He is originally from Texas but spends most of his time in Miami Beach now. Since discovering bitcoin in 2012 he has promoted it to anyone that will listen and is frequently seen at bitcoin meetups in South Florida.
 
 He blogs about the future at <a href="http://www.adrianchilders.com">www.adrianchilders.com</a>.

--- a/_people/alan-reiner-bitcoin-security-expert.md
+++ b/_people/alan-reiner-bitcoin-security-expert.md
@@ -1,20 +1,17 @@
 ---
 title: Alan Reiner
 seotitle: Alan Reiner - Bitcoin Security Expert
-author: Alan Reiner
-authorurl: https://www.weusecoins.com/alan-reiner-bitcoin-security-expert
-published: true
 img: /images/alan-reiner.png
 name: Alan Reiner
 position: Founder, Armory
 education: Graduate Degrees in Engineering Mechanics and Applied Mathematics
-experience: 
+experience:
 short_desc: Alan Reiner was the former CTO and Founder of Armory.
-long_desc: 
-affiliations: 
-twitter: 
+long_desc:
+affiliations:
+twitter:
 github: etotheipi
-residence: 
+residence:
 ---
 Alan Reiner was the former CTO and Founder of <a href="/armory/">Armory</a>. He is a cryptocurrency security pioneer and widely recognized as a world leading Bitcoin security expert and as a trusted source for security best practices. Under his leadership Armory innovated new Bitcoin security features and enterprise-grade functionality.
 

--- a/_people/alessandro-premoli.md
+++ b/_people/alessandro-premoli.md
@@ -1,19 +1,16 @@
 ---
 title: Alessandro Premoli
-author: Alessandro Premoli - CTO Bitgold
 seotitle: Alessandro Premoli - CTO Bitgold
-authorurl: /alessandro-premoli/
-published: true
 img: /images/alessandro-premoli.png
-name: Alessandro Premoli
 position: CTO Bitgold
 education: Masters Degree in Informatics from the University of Milano-Bicocca
-experience: 
+experience:
 short_desc: Alessandro "Alex" Premoli is the Chief Technology Officer of BitGold.
-long_desc: 
-affiliations: BitGold
-twitter: 
-github: 
+long_desc:
+affiliations:
+  - BitGold
+twitter:
+github:
 residence: Italy
 ---
 Alessandro "Alex" Premoli is the Chief Technology Officer of <a href="/bitgold/">BitGold</a>. He is the architect of the BitGold proprietary platform, and leads the BitGold development team in Milan, Italy. He is passionate about open-source projects and is an active committer to the FreeBSD Project under the moniker "Alex Dupre".
@@ -25,21 +22,13 @@ Over the last decade, he has developed encrypted storage and messaging systems f
 Alex has been an important member of the cryptocurrency community for several years and has been involved in the [Ripple financial protocol](/what-is-ripple/) since its early days.
 
 ## Education
- 
+
 He holds a Masters Degree in Informatics from the University of Milano-Bicocca.
 
 ## Article by Alessandro Premoli
 
-<ul>
-<li><a href="http://www.slideshare.net/BitGold/bit-gold-2015-0501-web-version">Bitgold Presentation</a></li>
-</ul>
+* [Bitgold Presentation](http://www.slideshare.net/BitGold/bit-gold-2015-0501-web-version)
 
 ## BitGold Executive Management Team Members
 
-<div class="similar-people-wrap">
-{% for person in site.people %}
-{% if person.affiliations contains 'BitGold' and page.name != person.name %}
-{% include similar-people.html %}
-{% endif %}
-{% endfor %}
-</div>
+{% include similar-people.html organization="BitGold" name=page.title %}

--- a/_people/alex-palantzas-bitcoin-expert.md
+++ b/_people/alex-palantzas-bitcoin-expert.md
@@ -1,8 +1,6 @@
 ---
-title: Alex Palantzas - Bitcoin Expert
-author: Alex Palantzas
-authorurl: https://www.weusecoins.com/alex-palantzas-bitcoin-expert/
-published: true
+title: Alex Palantzas
+seotitle: Alex Palantzas - Bitcoin Expert
 ---
 
 About Alex a Bitcoin expert.

--- a/_people/andreas-antonopoulos-bitcoin-expert.md
+++ b/_people/andreas-antonopoulos-bitcoin-expert.md
@@ -1,20 +1,18 @@
 ---
 title: Andreas M. Antonopoulos
 seotitle: Andreas M. Antonopoulos - Bitcoin Expert
-author: Andreas M. Antonopoulos
-authorurl: /andreas-antonopoulos-bitcoin-expert/
-published: true
 img: /images/andreas-antonopoulos.jpg
 name: Andreas M. Antonopoulos
 position: Author, Mastering Bitcoin
 education: Degrees in Computer Science, Data Communications and Distributed Systems from University College London
-experience: 
+experience:
 short_desc: Andreas M. Antonopoulos is a technologist and serial entrepreneur who has become one of the most well-known and well-respected figures in bitcoin.
-long_desc: 
-affiliations: Let's Talk Bitcoin
+long_desc:
+affiliations:
+  - Let's Talk Bitcoin
 twitter: aantonop
 github: aantonop
-residence: 
+residence:
 website: https://antonopoulos.com/
 cats: [public speaker, book author, bitcoin expert, featured]
 ---
@@ -22,15 +20,15 @@ Andreas M. Antonopoulos is a technologist and serial entrepreneur who has become
 
 ## Mastering Bitcoin
 
-Andreas is the author of *Mastering Bitcoin*, a book on the basics and technical aspects of Bitcoin. The book was published in December 2014 and is [available for free on GitHub](https://github.com/bitcoinbook/bitcoinbook). 
+Andreas is the author of *Mastering Bitcoin*, a book on the basics and technical aspects of Bitcoin. The book was published in December 2014 and is [available for free on GitHub](https://github.com/bitcoinbook/bitcoinbook).
 
 ## Blockchain.info
 
-Antonopoulos served as Blockchain.info's Chief Security Officer for eight months. He currently serves as an advisor to its board. 
+Antonopoulos served as Blockchain.info's Chief Security Officer for eight months. He currently serves as an advisor to its board.
 
 ## Public Speaking
 
-A former teacher, Andreas has used his skills to become one of the most recognized Bitcoin public speakers. He [made an appearance at the Canadian Senate](https://www.youtube.com/watch?v=xUNGFZDO8mM), has been [featured on the Joe Rogan Experience](https://www.youtube.com/watch?v=5wwbzwUXfgc), and hundreds more of his speaking appearances can be found on [YouTube](https://www.youtube.com/results?q=andreas+antonopoulos+bitcoin&sp=CAM%253D). 
+A former teacher, Andreas has used his skills to become one of the most recognized Bitcoin public speakers. He [made an appearance at the Canadian Senate](https://www.youtube.com/watch?v=xUNGFZDO8mM), has been [featured on the Joe Rogan Experience](https://www.youtube.com/watch?v=5wwbzwUXfgc), and hundreds more of his speaking appearances can be found on [YouTube](https://www.youtube.com/results?q=andreas+antonopoulos+bitcoin&sp=CAM%253D).
 
 ## History
 

--- a/_people/andy-ofiesh-bitcoin-security-expert.md
+++ b/_people/andy-ofiesh-bitcoin-security-expert.md
@@ -1,20 +1,18 @@
 ---
 title: Andy O'Fiesh
 seotitle: Andy O'Fiesh - Bitcoin Security Expert
-author: Andy O'Fiesh
-authorurl: https://www.weusecoins.com/andy-ofiesh-bitcoin-security-expert
-published: true
 img: /images/andy-ofiesh.png
 name: Andy O'Fiesh
 position: Developer, Armory
 education: Degree in Systems Engineering & Graduate Degrees in Computer Science and Computer Systems Engineering
-experience: 
-short_desc: Andy O'Fiesh is a developer of the Armory Bitcoin wallet. 
-long_desc: 
-affiliations: Armory
-twitter: 
-github: 
-residence: 
+experience:
+short_desc: Andy O'Fiesh is a developer of the Armory Bitcoin wallet.
+long_desc:
+affiliations:
+  - Armory
+twitter:
+github:
+residence:
 cats: [armory, bitcoin security expert]
 ---
 Andy O'Fiesh was the second developer to join [Alan Reiner](/alan-reiner-bitcoin-security-expert/) working at [Armory](/armory/) on developing the advanced <a href="https://www.bitcoinarmory.com/">Armory Bitcoin wallet</a> features. He is a senior software developer with over 20 years of experience developing enterprise level software for companies such as Juniper Networks, Intel and Nortel.
@@ -33,6 +31,6 @@ Andy holds a degree in systems engineering and graduate degrees in computer scie
 
 ## Videos
 
-Perianne Boring interviews Andy at Inside Bitcoins NY: 
+Perianne Boring interviews Andy at Inside Bitcoins NY:
 
 <iframe width="700" height="394" src="https://www.youtube.com/embed/qTgf2LZHv9A" frameborder="0" allowfullscreen></iframe>

--- a/_people/arthur-hayes.md
+++ b/_people/arthur-hayes.md
@@ -5,13 +5,14 @@ img: /images/arthur-hayes.png
 name: Arthur Hayes
 position: CEO, BitMEX
 education: BA in Economics from the Wharton School of Business at the University of Pennsylvania
-experience: 
-short_desc: Arthur Hayes is the CEO of BitMEX. 
-long_desc: 
-affiliations: BitMEX
-twitter: 
-github: 
-residence: 
+experience:
+short_desc: Arthur Hayes is the CEO of BitMEX.
+long_desc:
+affiliations:
+  - BitMEX
+twitter:
+github:
+residence:
 cats: [ ]
 ---
 
@@ -19,7 +20,7 @@ Arthur Hayes serves as the CEO of BitMEX and obtained his BA in Economics at the
 
 ## History
 
-After leaving Citi in 2013, Arthur began trading and investing in Bitcoin. He primarily engages in arbitrage between different spot exchanges, and between Bitcoin derivatives. After trading Bitcoin derivatives on various exchanges for some time, he thought that there is space for a Bitcoin derivative exchange modelled after existing exchanges where fiat currency derivatives are traded. 
+After leaving Citi in 2013, Arthur began trading and investing in Bitcoin. He primarily engages in arbitrage between different spot exchanges, and between Bitcoin derivatives. After trading Bitcoin derivatives on various exchanges for some time, he thought that there is space for a Bitcoin derivative exchange modelled after existing exchanges where fiat currency derivatives are traded.
 
 ## BitMEX
 

--- a/_people/balaji-srinivasan.md
+++ b/_people/balaji-srinivasan.md
@@ -1,31 +1,30 @@
 ---
-title: Balaji Srinivasan 
+title: Balaji Srinivasan
 seotitle: Balaji Srinivasan - CEO, 21
 img: /images/balaji-srinivasan.png
-name: Balaji Srinivasan
 position: CEO, 21
-education: 
-experience: 
-short_desc: Balaji Srinivasan is the Founder and CEO of 21. 
-long_desc: 
+education:
+experience:
+short_desc: Balaji Srinivasan is the Founder and CEO of 21.
+long_desc:
 affiliations: [21, Counsyl]
 twitter: balajis
 github: balajis
-residence: 
+residence:
 cats: featured
-website: 
+website:
 ---
-Balaji Srinivasan is the Founder and CEO of [21](/21/), and a General Board Partner at [a16z](http://a16z.com/). 
+Balaji Srinivasan is the Founder and CEO of [21](/21/), and a General Board Partner at [a16z](http://a16z.com/).
 
-Srinivasan gained recognition as the co-founder of Counsyl, a genomics company that now DNA tests ~3% of births in the United States. 
+Srinivasan gained recognition as the co-founder of Counsyl, a genomics company that now DNA tests ~3% of births in the United States.
 
 He is outspoken in his beliefs that “[software is reorganizing the world](http://www.wired.com/2013/11/software-is-reorganizing-the-world-and-cloud-formations-could-lead-to-physical-nations )”. Srinivasan resigned from Counsyl in order to pursue his interest in other technologies.  
 
-Srinivasan lectures in Stanford’s Departments of Statistics and Computer Science, and teaches Stanford's [Bitcoin Engineering Course](http://bitcoin.stanford.edu/). 
+Srinivasan lectures in Stanford’s Departments of Statistics and Computer Science, and teaches Stanford's [Bitcoin Engineering Course](http://bitcoin.stanford.edu/).
 
 ## 21
 
-Srinivasan is the founder of 21, the maker of what it calls the world’s first "Bitcoin computer". 21 received its first funding round of $5.05 million in March-2013, followed by another round of $116 million in March-2015. 
+Srinivasan is the founder of 21, the maker of what it calls the world’s first "Bitcoin computer". 21 received its first funding round of $5.05 million in March-2013, followed by another round of $116 million in March-2015.
 
 ## a16z
 
@@ -33,7 +32,7 @@ In December 2013, Srinivasan [joined tech VC firm Andreessen Horowitz](http://bl
 
 ## Quotes
 
-On [closing Bitcoin loops](http://www.coindesk.com/21-ceo-balaji-srinivasan-bitcoin-job-fair/): 
+On [closing Bitcoin loops](http://www.coindesk.com/21-ceo-balaji-srinivasan-bitcoin-job-fair/):
 
 > If you're giving bitcoin and getting back dollars, this is not good for the price. If you have closed loops, you have something where you're getting value out of bitcoin without selling it.
 

--- a/_people/boaz-bechar.md
+++ b/_people/boaz-bechar.md
@@ -1,23 +1,20 @@
 ---
 title: Boaz Bechar
 seotitle: Boaz Bechar - CEO & Founder, BlockTrail
-author: Boaz Bechar
-authorurl: https://www.weusecoins.com/boaz-bechar/
-published: true
 img: /images/boaz-bechar.png
-name: Boaz Bechar
 position: CEO & Founder, BlockTrail
-education: 
-experience: 
+education:
+experience:
 short_desc: Boaz Bechar is the CEO and founder of BlockTrail.
-long_desc: 
-affiliations: BlockTrail
+long_desc:
+affiliations:
+  - BlockTrail
 twitter: boazeb
-github: 
-residence: 
+github:
+residence:
 cats: [ ]
 ---
-Boaz Bechar is the CEO and founder of BlockTrail. He is an entrepreneur with over 10 years experience in leading tech startups. 
+Boaz Bechar is the CEO and founder of BlockTrail. He is an entrepreneur with over 10 years experience in leading tech startups.
 
 ## History
 

--- a/_people/bobby-ong.md
+++ b/_people/bobby-ong.md
@@ -1,20 +1,17 @@
 ---
 title: Bobby Ong
 seotitle: Bobby Ong - Co-founder, CoinGecko
-author: Bobby Ong
-authorurl: http://www.weusecoins.com/bobby-ong
-published: true
 img: /images/bobby-ong.png
-name: Bobby Ong
 position: Co-founder, CoinGecko
 education: BSc. in Economics from University College London
-experience: 
+experience:
 short_desc: Bobby Ong is the co-founder of CoinGecko.
-long_desc: 
-affiliations: CoinGecko
+long_desc:
+affiliations:
+  - CoinGecko
 twitter: bobbyong
-github: 
-residence: 
+github:
+residence:
 cats: [ ]
 website: https://www.coingecko.com
 ---

--- a/_people/brian-armstrong.md
+++ b/_people/brian-armstrong.md
@@ -2,40 +2,39 @@
 title: Brian Armstrong
 seotitle: Brian Armstrong - CEO, Coinbase
 img: /images/brian-armstrong.png
-name: Brian Armstrong
 position: CEO, Coinbase
 education: Bachelor’s Degree in Computer Science; Bachelor’s Degree in Economics; Master’s Degree in Computer Science
-experience: 
+experience:
 short_desc: Brian Armstrong is the co-founder and CEO of Coinbase.
-long_desc: 
+long_desc:
 affiliations: [Coinbase]
 twitter: brian_armstrong
-github: barmstrong 
-residence: 
+github: barmstrong
+residence:
 cats: [ ]
-website: 
+website:
 ---
-Brian Armstrong is the co-founder and CEO of [Coinbase](/coinbase-review/). Armstrong founded the company, which has become one of the largest in the Bitcoin space, in June 2012. 
+Brian Armstrong is the co-founder and CEO of [Coinbase](/coinbase-review/). Armstrong founded the company, which has become one of the largest in the Bitcoin space, in June 2012.
 
 ## Experience
 
-Before founding Coinbase, Armstrong worked as a Software Engineer at AirBNB from 2011-2012. Previously, he founded UniversityTutory.com and also worked as a software engineer at CarWoo.com. 
+Before founding Coinbase, Armstrong worked as a Software Engineer at AirBNB from 2011-2012. Previously, he founded UniversityTutory.com and also worked as a software engineer at CarWoo.com.
 
-## Education 
+## Education
 
-Armstrong holds three degrees from Rice University: a Bachelor’s Degree in Computer Science, Bachelor’s Degree in Economics, and a Master’s Degree in Computer Science. 
+Armstrong holds three degrees from Rice University: a Bachelor’s Degree in Computer Science, Bachelor’s Degree in Economics, and a Master’s Degree in Computer Science.
 
 ## Controversy
 
-As the CEO of one of the largest and well-funded Bitcoin companies, Armstrong has become one of the more prominent figures in Bitcoin. 
+As the CEO of one of the largest and well-funded Bitcoin companies, Armstrong has become one of the more prominent figures in Bitcoin.
 
 Most of the controversy surrounding Armstrong stems from his support of two fork attempts of the Bitcoin network: Bitcoin Classic and Bitcoin XT.  
 
-Bitcoin XT was the first attempt at a hard fork and Armstrong showed initial support for the software on December 26, 2015 [via Twitter](https://twitter.com/brian_armstrong/status/680902843784544256): 
+Bitcoin XT was the first attempt at a hard fork and Armstrong showed initial support for the software on December 26, 2015 [via Twitter](https://twitter.com/brian_armstrong/status/680902843784544256):
 
 > Coinbase is now running BitcoinXT (BIP101) in production as an experiment
 
-Bitcoin XT proposed an immediate block size increase to 8 MB block which was to be doubled every two years. Armstrong and the XT developers, [Gavin Andresen](/gavin-andresen/) and Mike Hearn, pushed the software as a scaling solution. Most of the technical community and [Bitcoin Core](/bitcoin-core/) developers, however, considered XT an attack on the network. Its 75% miner activation threshold was also considered low because it created potential for a fork of the network which would create two separate chains. 
+Bitcoin XT proposed an immediate block size increase to 8 MB block which was to be doubled every two years. Armstrong and the XT developers, [Gavin Andresen](/gavin-andresen/) and Mike Hearn, pushed the software as a scaling solution. Most of the technical community and [Bitcoin Core](/bitcoin-core/) developers, however, considered XT an attack on the network. Its 75% miner activation threshold was also considered low because it created potential for a fork of the network which would create two separate chains.
 
 Since Bitcoin is a consensus network, many took issue with the fact that Armstrong supported a proposal lacking support by most Bitcoin developers and the technical community. XT fizzled out when its lead developer, Mike Hearn, [announced that he's moving away from Bitcoin development](https://medium.com/@octskyward/the-resolution-of-the-bitcoin-experiment-dabb30201f7#.xoxkjf68c).
 
@@ -43,13 +42,13 @@ Bitcoin Classic was the second major hard fork proposal supported by Armstrong. 
 
 > please support BitcoinClassic and help us move to a world with multiple competing Bitcoin forks
 
-Bitcoin Classic proposes a hard fork to 2MB block size once--like Bitcoin XT--75% of miners mine Classic blocks. Because 75% is far from consensus and much less than the 95% generally required for soft forks, some consider Classic a hostile attempt to fork Bitcoin and create two separate chains. 
+Bitcoin Classic proposes a hard fork to 2MB block size once--like Bitcoin XT--75% of miners mine Classic blocks. Because 75% is far from consensus and much less than the 95% generally required for soft forks, some consider Classic a hostile attempt to fork Bitcoin and create two separate chains.
 
-Armstrong gained support among users wishing to see an increase in the block size. Many disagree, however, and criticize his second motion of support for an intentional hardfork of Bitcoin. 
+Armstrong gained support among users wishing to see an increase in the block size. Many disagree, however, and criticize his second motion of support for an intentional hardfork of Bitcoin.
 
 ## Quotes:
 
-On Bitcoin as [reserve currency](https://twitter.com/brian_armstrong/status/624422827307831296): 
+On Bitcoin as [reserve currency](https://twitter.com/brian_armstrong/status/624422827307831296):
 
 > Many will find this crazy, but I think bitcoin could surpass the dollar as reserve currency within 10-15 years.
 

--- a/_people/brian-donegan.md
+++ b/_people/brian-donegan.md
@@ -1,20 +1,17 @@
 ---
 title: Brian Donegan
 seotitle: Brian Donegan - Isle of Man Government
-author: Brian Donegan
-authorurl: https://www.weusecoins.com/
-published: true
 img: /images/brian-donegan.png
-name: Brian Donegan
 position: Business Development Manager, Isle of Man government
-education: 
-experience: 
+education:
+experience:
 short_desc: Brian Donegan is the business development manager for the Isle of Man government.
-long_desc: 
-affiliations: Isle of Man Government
-twitter: 
-github: 
-residence: 
+long_desc:
+affiliations:
+  - Isle of Man Government
+twitter:
+github:
+residence:
 cats: [ ]
 ---
 Brian Donegan is the business development manager for the Isle of Man government. He has been instrumental in bringing Bitcoin and cryptocurrency businesses to the Isle of Man.

--- a/_people/brian-hoffman.md
+++ b/_people/brian-hoffman.md
@@ -2,18 +2,19 @@
 title: Brian Hoffman
 seotitle: Brian Hoffman - CEO, OB1
 img: /images/brian-hoffman.jpg
-name: Brian Hoffman
 position: CEO, OB1
-education: 
-experience: 
+education:
+experience:
 short_desc: Brian Hoffman is the CEO of OB1, and lead developer of OpenBazaar.
-long_desc: 
-affiliations: [OpenBazaar, OB1]
+long_desc:
+affiliations:
+  - OpenBazaar
+  - OB1
 twitter: brianchoffman
 github: hoffmabc
-residence: 
+residence:
 cats: [ ]
-website: 
+website:
 ---
 Brian Hoffman is the CEO of OB1, which is the parent company of the decentralized marketplace [OpenBazaar](/openbazaar/).
 
@@ -23,13 +24,13 @@ OpenBazaar began as Dark Market, when Amir Taaki published its first code in 201
 
 ## Quotes
 
-On [OpenBazaar's goals](http://fortune.com/2015/06/25/openbazaar-not-silk-road/): 
+On [OpenBazaar's goals](http://fortune.com/2015/06/25/openbazaar-not-silk-road/):
 
 > The vision is opening trade for every kind of activity. We’re not building a marketplace that specifies one kind of user or trade, we just build the network and it’s up to the participants to decide what goes across that network, much like the Internet. Same goes for bitcoin. I think some of these new technologies, early on, get adopted by some unsavory groups, because they’re the ones that are most willing to be risky about the way they conduct business.
 
-On [OpenBazaar](http://insidebitcoins.com/news/brian-hoffman-on-why-vcs-arent-scared-to-invest-in-openbazaar/33846): 
+On [OpenBazaar](http://insidebitcoins.com/news/brian-hoffman-on-why-vcs-arent-scared-to-invest-in-openbazaar/33846):
 
-> OpenBazaar is not a company; it’s not a business. We don’t have servers in some data center collecting all this data and controlling our users. It’s just a protocol. It’s just a bunch of computers talking to each other, so what happens on that network is up to the whim of the users. 
+> OpenBazaar is not a company; it’s not a business. We don’t have servers in some data center collecting all this data and controlling our users. It’s just a protocol. It’s just a bunch of computers talking to each other, so what happens on that network is up to the whim of the users.
 
 ## Links
 
@@ -38,13 +39,8 @@ On [OpenBazaar](http://insidebitcoins.com/news/brian-hoffman-on-why-vcs-arent-sc
 
 ## More OpenBazaar Developers
 
-<div class="similar-people-wrap">
-{% for person in site.people %}
-{% if person.affiliations contains 'OpenBazaar' and page.name != person.name %}
-{% include similar-people.html %}
-{% endif %}
-{% endfor %}
-</div>
+{% assign organization = page.affiliations[0] %}
+{% include similar-people.html organization=organization name=page.title %}
 
 ## Video
 

--- a/_people/chris-derose.md
+++ b/_people/chris-derose.md
@@ -1,27 +1,26 @@
 ---
-title:  Chris DeRose 
+title:  Chris DeRose
 seotitle: Chris DeRose - Counterparty Community Director
 img: /images/chris-derose.jpg
-name:  Chris DeRose 
 position: Counterparty Community Director
-education: 
-experience: 
+education:
+experience:
 short_desc: Chris DeRose is the Counterparty Community Director and a writer at American Banker.
-long_desc: 
+long_desc:
 affiliations: [Counterparty Foundation, American Banker]
 twitter: derosetech
 github: brighton36
-residence: 
+residence:
 cats: [ ]
 website: https://www.chrisderose.com/
 ---
 Chris DeRose is the Counterparty Community Director and a writer at [American Banker](https://www.chrisderose.com#articles-i-ve-written).
 
-DeRose's articles at American Banker highlight Bitcoin's advantages over private blockchains, and how Bitcoin and blockchain technology is set to change finance. 
- 
+DeRose's articles at American Banker highlight Bitcoin's advantages over private blockchains, and how Bitcoin and blockchain technology is set to change finance.
+
 ## Quotes
 
-On [alternate blockchains](http://www.americanbanker.com/bankthink/why-the-bitcoin-blockchain-beats-out-competitors-1075100-1.html): 
+On [alternate blockchains](http://www.americanbanker.com/bankthink/why-the-bitcoin-blockchain-beats-out-competitors-1075100-1.html):
 
 > This Bitcoin network effect shows no signs of slowing down. But if the last six years has shown us anything in the blockchain space, it's that alternate chains — and their believers — are ten satoshis a dozen.
 

--- a/_people/chris-pacia.md
+++ b/_people/chris-pacia.md
@@ -1,19 +1,20 @@
 ---
 title: Chris Pacia
 seotitle: Chris Pacia - Senior Developer, OB1
-img: /images/chris-pacia.jpg 
-name: Chris Pacia
+img: /images/chris-pacia.jpg
 position: Senior Developer, OB1
 education: Master of Business Administration from Rutgers Business School
-experience: 
+experience:
 short_desc: Chris Pacia is a Senior Developer at OB1/OpenBazaar.
-long_desc: 
-affiliations: [OB1, OpenBazaar]
+long_desc:
+affiliations:
+  - OpenBazaar
+  - OB1
 twitter: chrispacia
 github: cpacia
-residence: 
-cats: [ ]
-website: 
+residence:
+cats: [ ] # what?
+website:
 ---
 Chris Pacia is a Senior Developer at OB1, the parent company of [OpenBazaar](/openbazaar/).
 
@@ -21,13 +22,13 @@ Chris Pacia is a Senior Developer at OB1, the parent company of [OpenBazaar](/op
 
 Pacia has been involved with a wide variety of Bitcoin projects.
 
-In early-2015, Pacia introduced a wallet called "Bitcoin Authenticator". The desktop wallet featured automatic 2-factor authentication by using multisignature with a smartphone as a second signing device. While the wallet received [positive feedback on reddit](https://www.reddit.com/r/Bitcoin/comments/2r64wn/bitcoin_authenticator_decentralized_twofactor/), it appears that no further development is being done on the project. 
+In early-2015, Pacia introduced a wallet called "Bitcoin Authenticator". The desktop wallet featured automatic 2-factor authentication by using multisignature with a smartphone as a second signing device. While the wallet received [positive feedback on reddit](https://www.reddit.com/r/Bitcoin/comments/2r64wn/bitcoin_authenticator_decentralized_twofactor/), it appears that no further development is being done on the project.
 
 In mid-2015, Pacia published [a Medium article](https://medium.com/@chrispacia/subspace-73059a1cff71) introducing [Subspace](https://github.com/cpacia/Subspace); a "messaging layer for Bitcoin". Development on Subspace also appears to have halted since Pacia joined OB1.
 
 ## Bitcoin Development
 
-Pacia has been vocal about his disagreement with the current path of [Bitcoin Core](/bitcoin-core/) development. He has come out against proposals like Lightning Network and replace by fee, and supports scaling solutions through hard forks to increase the block size. His thoughts on these subjects can be found in the many articles published [on his blog](https://chrispacia.wordpress.com/). 
+Pacia has been vocal about his disagreement with the current path of [Bitcoin Core](/bitcoin-core/) development. He has come out against proposals like Lightning Network and replace by fee, and supports scaling solutions through hard forks to increase the block size. His thoughts on these subjects can be found in the many articles published [on his blog](https://chrispacia.wordpress.com/).
 
 ## Links
 
@@ -35,10 +36,5 @@ Matt Whitlock and Chris Pacia Debate Replace by Fee Proposals (Podcast) - [NeoCa
 
 ## More OpenBazaar Developers
 
-<div class="similar-people-wrap">
-{% for person in site.people %}
-{% if person.affiliations contains 'OpenBazaar' and page.name != person.name %}
-{% include similar-people.html %}
-{% endif %}
-{% endfor %}
-</div>
+{% assign organization = page.affiliations[0] %}
+{% include similar-people.html organization=organization name=page.title %}

--- a/_people/cory-fields.md
+++ b/_people/cory-fields.md
@@ -2,25 +2,24 @@
 title: Cory Fields
 seotitle: Cory Fields - Bitcoin Core Developer
 img: /images/cory-fields.png
-name: Cory Fields 
 position: Bitcoin Core Developer
-education: 
-experience: 
+education:
+experience:
 short_desc: Cory Fields is a Bitcoin Core Developer.
-long_desc: 
+long_desc:
 affiliations: [MIT Digital Currency Initiative, Bitcoin Core]
-twitter: 
+twitter:
 github: theuni
-residence: 
+residence:
 cats: [ ]
-website: 
+website:
 ---
-Cory Fields is a [Bitcoin Core](/bitcoin-core/) Developer. He works alongside [Gavin Andresen](/gavin-andresen/) and [Wladimir van der Laan](/wladimir-van-der-laan/) at MIT's Digital Currency Initiative. 
+Cory Fields is a [Bitcoin Core](/bitcoin-core/) Developer. He works alongside [Gavin Andresen](/gavin-andresen/) and [Wladimir van der Laan](/wladimir-van-der-laan/) at MIT's Digital Currency Initiative.
 
-Previously, Fields served on the board of The XBMC Foundation and worked as a developer on XBMC. 
+Previously, Fields served on the board of The XBMC Foundation and worked as a developer on XBMC.
 
 ## Quotes
 
-On [Bitcoin's design](http://coinjournal.net/mits-cory-fields-contentiousness-in-bitcoin-is-sign-of-good-health/): 
+On [Bitcoin's design](http://coinjournal.net/mits-cory-fields-contentiousness-in-bitcoin-is-sign-of-good-health/):
 
 > If the fighting stops, if it becomes easy to push through a hard-fork, a difficult change, a major change, then at that point we know we have lost and it’s not an interesting system anymore. If it’s that easy to manipulate, then it’s not worth working on this.

--- a/_people/daniel-crandall.md
+++ b/_people/daniel-crandall.md
@@ -1,20 +1,18 @@
 ---
 title: Daniel Crandall
 seotitle: Daniel Crandall - CFO Bitgold
-author: Daniel Crandall - CFO Bitgold
-authorurl: /daniel-crandall/
-published: true
 img: /images/daniel-crandall.png
 name: Daniel Crandall
 position: CFO Bitgold
 education: Bachelor of Accounting from Brock University
-experience: 
+experience:
 short_desc: CPA, CA and is the CFO of BitGold.
-long_desc: 
-affiliations: BitGold
-twitter: 
-github: 
-residence: 
+long_desc:
+affiliations:
+  - BitGold
+twitter:
+github:
+residence:
 ---
 Daniel Crandall is a CPA, CA and is the <b>CFO</b> of <a href="/bitgold/">BitGold</a>.
 
@@ -31,10 +29,5 @@ He holds an Honours Bachelor of Accounting (Co-op) degree from Brock University.
 
 ## BitGold Executive Management Team Members
 
-<div class="similar-people-wrap">
-{% for person in site.people %}
-{% if person.affiliations contains 'BitGold' and page.name != person.name %}
-{% include similar-people.html %}
-{% endif %}
-{% endfor %}
-</div>
+{% assign organization = page.affiliations[0] %}
+{% include similar-people.html organization=organization name=page.title %}

--- a/_people/daniel-scott.md
+++ b/_people/daniel-scott.md
@@ -1,22 +1,19 @@
 ---
 title: Daniel Scott
 seotitle: Daniel Scott - Co-founder, CoinCorner
-author: Daniel Scott
-authorurl: http://www.weusecoins.com/daniel-scott
-published: true
 img: /images/daniel-scott.jpg
-name: Daniel Scott
 position: Co-founder, CoinCorner
-education: 
-experience: 
+education:
+experience:
 short_desc: Daniel Scott is the Co-founder of CoinCorner.
-long_desc: 
-affiliations: CoinCorner
+long_desc:
+affiliations:
+  - CoinCorner
 twitter: DannyLScott
-github: 
-residence: 
+github:
+residence:
 cats: [ ]
 ---
-Daniel Scott co-founded CoinCorner in 2014 as a solution to the problem of being able to [buy bitcoins](https://www.coincorner.com/) easily in the UK. Since then he has become a leading figure in the [Isle of Man's growing bitcoin community](/bitcoin-isle-of-man/). 
+Daniel Scott co-founded CoinCorner in 2014 as a solution to the problem of being able to [buy bitcoins](https://www.coincorner.com/) easily in the UK. Since then he has become a leading figure in the [Isle of Man's growing bitcoin community](/bitcoin-isle-of-man/).
 
 As a manager of a successful [bitcoin exchange](/en/how-buy-bitcoins-online-best-bitcoin-exchange-rate-bitcoin-price/) startup and board member of the [MDCA](http://www.mdca.im/) (Manx Digital Coin Association) he is well placed to help grow the community and push bitcoin forward for the better.

--- a/_people/darrell-macmullin.md
+++ b/_people/darrell-macmullin.md
@@ -1,20 +1,16 @@
 ---
 title: Darrell MacMullin
 seotitle: Darrell MacMullin - CEO Bitgold
-author: Darrell MacMullin - CEO Bitgold
-authorurl: /darrell-macmullin/
-published: true
 img: /images/darrell-macmullin.png
-name: Darrell MacMullin
 position: CEO Bitgold
-education: 
-experience: 
-short_desc: 
-long_desc: 
+education:
+experience:
+short_desc:
+long_desc:
 affiliations: [BitGold]
-twitter: 
-github: 
-residence: 
+twitter:
+github:
+residence:
 ---
 <a href="/darrell-macmullin/">Darrell MacMullin</a> - Chief Executive Officer of <a href="/bitgold/">BitGold</a>.
 
@@ -36,10 +32,5 @@ Prior to PayPal Darrell was part of the successful launches and rapid growth of 
 
 ## BitGold Executive Management Team Members
 
-<div class="similar-people-wrap">
-{% for person in site.people %}
-{% if person.affiliations contains 'BitGold' and page.name != person.name %}
-{% include similar-people.html %}
-{% endif %}
-{% endfor %}
-</div>
+{% assign organization = page.affiliations[0] %}
+{% include similar-people.html organization=organization name=page.title %}

--- a/_people/diego-gutierrez.md
+++ b/_people/diego-gutierrez.md
@@ -2,28 +2,27 @@
 title: Diego Gutierrez
 seotitle: Diego Gutierrez - CEO, Rootstock
 img: /images/diego-gutierrez.jpg
-name: Diego Gutierrez
 position: CEO, Rootstock
-education: 
-experience: 
+education:
+experience:
 short_desc: Diego Gutierrez is the CEO of Rootstock and RSK Labs.
-long_desc: 
+long_desc:
 affiliations: [Rootstock, RSK Labs]
 twitter: dieguito
-github: 
-residence: 
+github:
+residence:
 cats: [ ]
-website: 
+website:
 ---
-[Diego Gutierrez](https://ar.linkedin.com/in/diegogutierrezzaldivar) is the CEO at Koibanx and President of Bitcoin Argentina NGO. In addition, Gutierrez  servers as the CEO of [Rootstock](http://www.rootstock.io/)/RSK Labs, a smart contracts platform built on Bitcoin. 
+[Diego Gutierrez](https://ar.linkedin.com/in/diegogutierrezzaldivar) is the CEO at Koibanx and President of Bitcoin Argentina NGO. In addition, Gutierrez  servers as the CEO of [Rootstock](http://www.rootstock.io/)/RSK Labs, a smart contracts platform built on Bitcoin.
 
 ## History
 
-He pioneered Web development in Argentina in 1995. He was a founding member of Clarín Digital (main local newspaper) and Patagon.com (financial institution sold to Banco Santander for 750MM) among others. He founded Koibanx, Xinergia, Cero a Cien and Restocoins. 
+He pioneered Web development in Argentina in 1995. He was a founding member of Clarín Digital (main local newspaper) and Patagon.com (financial institution sold to Banco Santander for 750MM) among others. He founded Koibanx, Xinergia, Cero a Cien and Restocoins.
 
 ## Rootstock & RSK Labs
 
-As an early-promoter of Bitcoin, Gutierrez understood how Bitcoin could help solve the problems of the unbanked. His Linkedin profile claims, however, that Bitcoin could not solve all issues "without Smart Contract capabilities volatility mitigation and execution of complex business rules in a trust-less environment". Gutierrez co-founded Rootstock and RSK Labs in 2015 in an attempt to tackle these issues. 
+As an early-promoter of Bitcoin, Gutierrez understood how Bitcoin could help solve the problems of the unbanked. His Linkedin profile claims, however, that Bitcoin could not solve all issues "without Smart Contract capabilities volatility mitigation and execution of complex business rules in a trust-less environment". Gutierrez co-founded Rootstock and RSK Labs in 2015 in an attempt to tackle these issues.
 
 ## Links
 

--- a/_people/dr-adam-back.md
+++ b/_people/dr-adam-back.md
@@ -2,17 +2,18 @@
 title: Dr. Adam Back
 img: /images/adam-back.png
 person: adamback
-name: Dr. Adam Back
 position: President, Blockstream
 education: Ph.D. in Computer Science from University of Exeter
-experience: 
-short_desc: 
-long_desc: 
+experience:
+short_desc:
+long_desc:
 img: /images/adam-back.png
-affiliations: Blockstream, Armory
+affiliations:
+  - Blockstream
+  - Armory
 twitter: adam3us
-github: 
-residence: 
+github:
+residence:
 ---
 
 Dr. Adam Back is the premier expert in the world on blockchain technology and a significant pioneer of applied cryptography for privacy applications. His brilliant applied cryptography work is cited in the <a href="/bitcoin.pdf">Bitcoin whitepaper</a> for the necessity of using a system like his invention Hashcash and the <a href="/assets/pdf/tor-design.pdf">TOR whitepaper</a> of the use of telescoping circuits.
@@ -36,14 +37,3 @@ He holds a Ph.D. in distributed systems and computer science from the University
 Adam Back on fungibility, privacy & identity:
 
 <iframe width="640" height="360" src="https://www.youtube.com/embed/3dAdI3Gzodo" frameborder="0" allowfullscreen></iframe>
-
-{% comment %}
-Articles by Dr. Adam Back
-<ul>
-	<li><a href="/adam-back-cypherpunks/">A Week With Adam Back - Part 1</a> - Why is Dr. Back so legendary?</li>
-	<li><a href="/adam-back-bitcoin-core-developers/">A Week With Adam Back - Part 2</a> - Who are the top Bitcoin developers?</li>
-	<li><a href="/adam-back-confidential-transactions/">A Week With Adam Back - Part 3</a> - Confidential Transactions</li>
-	<li><a href="/adam-back-lightning-network/">A Week With Adam Back - Part 4</a> - Lightning Network</li>
-	<li><a href="/adam-back-sidechains/">A Week With Adam Back - Part 5</a> - Sidechains</li>
-</ul>
-{% endcomment %}

--- a/_people/edmund-moy.md
+++ b/_people/edmund-moy.md
@@ -2,22 +2,21 @@
 title: Edmund Moy
 seotitle: Edmund Moy - Former Director of the US Mint
 img: /images/edmund-moy.png
-name: Edmund Moy
 position: Former Director of the US Mint
 education: Bachelors of Arts in Economics, International Relations, and Political Science from University of Wisconsin–Madison
-experience: 
+experience:
 short_desc: Edmund Moy served as the 38th Director of the US Mint.
-long_desc: 
+long_desc:
 affiliations: []
 twitter: EdmundCMoy
-github: 
-residence: 
+github:
+residence:
 cats: [ ]
-website: 
+website:
 ---
 Edmund Moy served as the 38th Director of the US Mint. Moy gained attention in the Bitcoin space in May-2014 when he [tweeted](https://twitter.com/EdmundCMoy/statuses/469500127179440128) about cryptocurrencies acting as competition against banks. A day later, he [wrote a blog post](http://edmoy.com/the-currency-revolution-courtesy-of-bitcoin/) claiming Bitcoin "will be a disruptor to the traditional notions of currency".
 
-Since his initial tweets about Bitcoin, Moy has become more involved with the digital currency. In November 2015, he attended the Bitcoin Investor Conference in Las Vegas. In March 2016, he was [featured as a guest](http://www.bitcoin.kn/2016/03/former-united-states-mint-director-ed-moy-discusses-coinage/) on the Bitcoin Knowledge Podcast. 
+Since his initial tweets about Bitcoin, Moy has become more involved with the digital currency. In November 2015, he attended the Bitcoin Investor Conference in Las Vegas. In March 2016, he was [featured as a guest](http://www.bitcoin.kn/2016/03/former-united-states-mint-director-ed-moy-discusses-coinage/) on the Bitcoin Knowledge Podcast.
 
 ## Quotes
 

--- a/_people/eli-dourado.md
+++ b/_people/eli-dourado.md
@@ -1,8 +1,5 @@
 ---
 title: Eli Dourado
-author: Eli Dourado
-authorurl: https://www.weusecoins.com/eli-dourado/
-published: true
 ---
 
 Eli Dourado is a research fellow at the Mercatus Center at George Mason University and director of its Technology Policy Program.

--- a/_people/eric-larcheveque.md
+++ b/_people/eric-larcheveque.md
@@ -1,34 +1,33 @@
 ---
-title: Eric Larchevêque 
+title: Eric Larchevêque
 seotitle: Eric Larchevêque - CEO, Ledger
 img: /images/eric-larcheveque.png 
-name: Eric Larchevêque 
 position: CEO, Ledger
-education: 
-experience: 
-short_desc: Eric Larchevêque is the CEO and Co-founder of Ledger. 
-long_desc: 
+education:
+experience:
+short_desc: Eric Larchevêque is the CEO and Co-founder of Ledger.
+long_desc:
 affiliations: [Ledger, la Maison du Bitcoin]
 twitter: ericlarch
 github: EricLarch
-residence: 
+residence:
 cats: [ ]
-website: 
+website:
 ---
 Eric Larchevêque is the CEO and Co-founder of [Ledger](/ledger/), a Bitcoin security company. He initially founded la Maison du Bitcoin, which in 2014 merged with BTChip and Chronocoin to become Ledger. He [stores more than 1,000 bitcoins](http://techcrunch.com/2016/01/10/ledger-wallet-is-one-of-the-most-secure-bitcoin-wallets-you-can-get/) on his personal [Ledger Nano](/bitcoin-ledger-wallet-review/).
 
 ## Quotes
 
-On the [Ledger Nano](https://www.chrisderose.com/video/interview-with-eric-larcheveque-ledger-wallet-founder): 
+On the [Ledger Nano](https://www.chrisderose.com/video/interview-with-eric-larcheveque-ledger-wallet-founder):
 
 > This is a hardware wallet based on a smart card. A smart card is a secure element, so it looks like a USB key but in fact, it's a small computer. And what does this small computer do? It holds on your private keys and it will also sign your transactions, so let's take a very simple example. This is a Chrome application so it works on any kind of computer. I put this in the USB port and then I will enter my pin code which I selected during initialization.
 
-On [hardware wallets](https://forum.bitcoin.com/ama-ask-me-anything/i-m-eric-larcheveque-co-founder-and-ceo-of-ledger-makers-of-hardware-wallets-ask-me-anything-t2926.html): 
+On [hardware wallets](https://forum.bitcoin.com/ama-ask-me-anything/i-m-eric-larcheveque-co-founder-and-ceo-of-ledger-makers-of-hardware-wallets-ask-me-anything-t2926.html):
 
 > Hardware wallets are going to evolve to personal security devices. Not only they'll be used to secure your bitcoins or other digital assets, but they'll manage your digital identities (FIDO) and secure your communications.
 
 ## Videos
 
-Interview with Eric Larchevêque from the 2014 North American Bitcoin Conference. 
+Interview with Eric Larchevêque from the 2014 North American Bitcoin Conference.
 
 <iframe width="740" height="416" src="https://www.youtube.com/embed/7hqID1OUeIs" frameborder="0" allowfullscreen></iframe>

--- a/_people/eric-lombrozo.md
+++ b/_people/eric-lombrozo.md
@@ -2,24 +2,23 @@
 title: Eric Lombrozo
 seotitle: Eric Lombrozo - Co-CEO, Ciphrex
 img: /images/eric-lombrozo.jpg
-name: Eric Lombrozo
 position: Co-CEO, Ciphrex
-education: 
-experience: 
+education:
+experience:
 short_desc: Eric Lombrozo is the Co-CEO and Co-founder of Ciphrex, and a Bitcoin Core developer.
-long_desc: 
+long_desc:
 affiliations: [Bitcoin Core, Ciphrex]
-twitter: 
+twitter:
 github: CodeShark
-residence: 
+residence:
 cats: [ ]
-website: 
+website:
 ---
-Eric Lombrozo is the Co-CEO and Co-founder of [Ciphrex](/ciphrex/), and a [Bitcoin Core](/bitcoin-core/) developer. Previously, he worked on other Bitcoin-related projects like CoinSurge and RingCoin. 
+Eric Lombrozo is the Co-CEO and Co-founder of [Ciphrex](/ciphrex/), and a [Bitcoin Core](/bitcoin-core/) developer. Previously, he worked on other Bitcoin-related projects like CoinSurge and RingCoin.
 
 ## Ciphrex
 
-Lombrozo founded Ciphrex with his father, Enrique, in 2013. Together they built the company's Bitcoin wallet, [mSIGNA](https://ciphrex.com/products/), which supports offline and multisignature transactions. 
+Lombrozo founded Ciphrex with his father, Enrique, in 2013. Together they built the company's Bitcoin wallet, [mSIGNA](https://ciphrex.com/products/), which supports offline and multisignature transactions.
 
 ## Links
 
@@ -34,6 +33,6 @@ On [increasing Bitcoin's block size](https://bitcoinmagazine.com/articles/bitcoi
 
 > As far as the block size itself, I don’t think there was much issue with bigger blocks. I don’t think many of the Core developers actually said, ‘No, we should never have bigger blocks.’ I think, for the most part, the idea of having bigger blocks is something that is appealing. We should find a way to have bigger blocks; we all want bigger blocks. But just increasing the blocks by changing a constant in the code presents a lot of very, very serious problems.
 
-On [Satoshi Nakamoto](https://ybitcoin.com/people/eric-lombrozo/): 
+On [Satoshi Nakamoto](https://ybitcoin.com/people/eric-lombrozo/):
 
 > Satoshi Nakamoto (Bitcoin’s pseudonymous inventor) deserves serious respect for having solved a major problem with computer networks—namely, how to use decentralized consensus to create a trustless peer-to-peer money transfer system. It is very admirable that he was able to implement the idea and prove it out. That has assured him a place in history.

--- a/_people/erik-voorhees.md
+++ b/_people/erik-voorhees.md
@@ -2,16 +2,15 @@
 title: Erik Voorhees
 img: /images/erik-voorhees.jpg
 seotitle: Erik Voorhees - CEO, ShapeShift.io
-name: Erik Voorhees
 position: CEO, ShapeShift.io
-education: 
-experience: 
+education:
+experience:
 short_desc: Erik Voorhees is the Founder and CEO of ShapeShift.io.
-long_desc: 
-affiliations: [ShapeShift] 
+long_desc:
+affiliations: [ShapeShift]
 twitter: erikvoorhees
-github: 
-residence: 
+github:
+residence:
 cats: [ ]
 website: http://moneyandstate.com/
 ---
@@ -21,10 +20,10 @@ Erik Voorhees is the creator and CEO of the instant bitcoin and altcoin exchange
 
 Erik Voorhees is co-founder of the Bitcoin company Coinapult, worked as Director of Marketing at BitInstant, and was founder and partial owner of the Bitcoin gambling website Satoshi Dice which was subsequently sold in July 2013 to an undisclosed buyer for 126,315 bitcoins which were valued at $11.5M.
 
-He was fined by the SEC for an unregistered stock offering related to SatoshiDice. 
+He was fined by the SEC for an unregistered stock offering related to SatoshiDice.
 
 ## Videos
 
-Erik Voorhees on the Bitcoin Knowledge Podcast: 
+Erik Voorhees on the Bitcoin Knowledge Podcast:
 
 <center><iframe width="700" height="394" src="https://www.youtube.com/embed/OYs_OTudg0s" frameborder="0" allowfullscreen></iframe></center>

--- a/_people/evan-duffield.md
+++ b/_people/evan-duffield.md
@@ -2,26 +2,25 @@
 title: Evan Duffield
 seotitle: Evan Duffield - Creator, Dash
 img: /images/evan-duffield.jpg
-name: Evan Duffield
 position: Creator, Dash
-education: 
-experience: 
+education:
+experience:
 short_desc: Evan Duffield is the creator of Dash.
-long_desc: 
+long_desc:
 affiliations: [DASH]
-twitter: 
-github: 
-residence: 
+twitter:
+github:
+residence:
 cats: [ ]
-website: 
+website:
 ---
-Evan Duffield is the creator of [Dash](/what-is-dash/), a cryptocurrency focused on privacy and speed. 
+Evan Duffield is the creator of [Dash](/what-is-dash/), a cryptocurrency focused on privacy and speed.
 
 ## History
 
 After discovering Bitcoin in 2010, Duffield wanted to add anonymity into the protocol. Duffield claims that [Bitcoin Core](/bitcoin-core/) developers would not have merged such code. Out of frustration, Duffield launched Dash in January-2014.  
 
-## Links 
+## Links
 
 DASH lead developer Evan Duffield discusses cryptocurrency experimentation - [Bitcoin Knowledge Podcast](http://www.bitcoin.kn/2016/02/dash-lead-developer-evan-duffield-discusses-cryptocurrency-experimentation/)
 

--- a/_people/fred-ehrsam.md
+++ b/_people/fred-ehrsam.md
@@ -2,24 +2,23 @@
 title: Fred Ehrsam
 seotitle: Fred Ehrsam - Co-founder, Coinbase
 img: /images/fred-ehrsam.png
-name: Fred Ehrsam
 position: Co-founder, Coinbase
 education: Bachelor’s Degree in Computer Science from Duke University
-experience: 
+experience:
 short_desc: Fred Ehrsam is the co-founder of Coinbase.
-long_desc: 
+long_desc:
 affiliations: [Coinbase]
 twitter: fehrsam
-github: 
-residence: 
+github:
+residence:
 cats: [ ]
-website: 
+website:
 ---
-Fred Ehrsam is the co-founder of [Coinbase](/coinbase-review/). Previously, Ehrsam worked as a trader in the Securities Division at Goldman Sachs, and in Portfolio Analytics at BlackRock. He holds a degree in Computer Science from Duke University. 
+Fred Ehrsam is the co-founder of [Coinbase](/coinbase-review/). Previously, Ehrsam worked as a trader in the Securities Division at Goldman Sachs, and in Portfolio Analytics at BlackRock. He holds a degree in Computer Science from Duke University.
 
 ## Recognition
 
-In 2014, Ehrsam [was named](http://ideas.time.com/2013/12/06/these-are-the-30-people-under-30-changing-the-world/slide/fred-ehrsam/) one of TIME's _30 People Under 30 Changing the World_. In the same year, [he was also included](http://www.forbes.com/pictures/mdg45edmhm/fred-ehrsam-25/) as part of Forbe's _30 Under 30_. 
+In 2014, Ehrsam [was named](http://ideas.time.com/2013/12/06/these-are-the-30-people-under-30-changing-the-world/slide/fred-ehrsam/) one of TIME's _30 People Under 30 Changing the World_. In the same year, [he was also included](http://www.forbes.com/pictures/mdg45edmhm/fred-ehrsam-25/) as part of Forbe's _30 Under 30_.
 
 ## Quotes
 

--- a/_people/gavin-andresen.md
+++ b/_people/gavin-andresen.md
@@ -2,36 +2,35 @@
 title:  Gavin Andresen
 img: /images/gavin-andresen.jpg
 seotitle: Gavin Andresen - Chief Scientist, Bitcoin Foundation
-name: Gavin Andresen
 position: Developer
 education: BSc. in Computer Science from Princeton University
-experience: 
+experience:
 short_desc: Gavin Andresen is a developer.
-long_desc: 
-affiliations: [Bitcoin Foundation, Bitcoin XT, Bitcoin Classic, Coinbase] 
+long_desc:
+affiliations: [Bitcoin Foundation, Bitcoin XT, Bitcoin Classic, Coinbase]
 twitter: gavinandresen
 github: gavinandresen
-residence: 
+residence:
 cats: [ ]
-website: 
+website:
 ---
-Gavin Andresen was an early contributor of code to Bitcoin with [overall GitHub commits](https://github.com/bitcoin/bitcoin/graphs/contributors) to Bitcoin Core around 484. 
+Gavin Andresen was an early contributor of code to Bitcoin with [overall GitHub commits](https://github.com/bitcoin/bitcoin/graphs/contributors) to Bitcoin Core around 484.
 
 In 2015, Andresen joined MIT's Digital Currency Initiative. Additionally, he serves as the Chief Scientist of the failed Bitcoin Foundation, and is an advisor to [Coinbase](/coinbase/) and [Zcash](https://z.cash/team.html).
 
 ## History with Bitcoin
 
-Andresen and Satoshi Nakamoto communicated often through Bitcointalk in early-2010. In mid-2010, Andresen alerted Satoshi that he had agreed to meet with the CIA to discuss Bitcoin. Satoshi disappeared shortly after. It's not clear, however, whether or not Gavin's meeting had anything to do with Satoshi's departure. 
+Andresen and Satoshi Nakamoto communicated often through Bitcointalk in early-2010. In mid-2010, Andresen alerted Satoshi that he had agreed to meet with the CIA to discuss Bitcoin. Satoshi disappeared shortly after. It's not clear, however, whether or not Gavin's meeting had anything to do with Satoshi's departure.
 
 ## Bitcoin Core
 
-From mid-2010 until April-2014, Andresen maintained control of the Bitcoin Core GitHub repository. On April 8, 2014, [Andresen stepped down](http://www.coindesk.com/gavin-andresen-steps-bitcoins-lead-developer/) and [Wladimir van der Laan](/wladimir-van-der-laan/) agreed to take over as Lead Maintainer of the Bitcoin Core repo. 
+From mid-2010 until April-2014, Andresen maintained control of the Bitcoin Core GitHub repository. On April 8, 2014, [Andresen stepped down](http://www.coindesk.com/gavin-andresen-steps-bitcoins-lead-developer/) and [Wladimir van der Laan](/wladimir-van-der-laan/) agreed to take over as Lead Maintainer of the Bitcoin Core repo.
 
-## Contributions to Bitcoin 
+## Contributions to Bitcoin
 
 ### Multisig (Pay to script hash)
 
-[BIPs 11](https://github.com/bitcoin/bips/blob/master/bip-0011.mediawiki), [13](https://github.com/bitcoin/bips/blob/master/bip-0013.mediawiki), and [16](https://github.com/bitcoin/bips/blob/master/bip-0016.mediawiki), published by Andresen in 2011 and 2012, were all part of the addition of multisiganture transactions--also known as Pay to Script Hash or P2SH--to Bitcoin. 
+[BIPs 11](https://github.com/bitcoin/bips/blob/master/bip-0011.mediawiki), [13](https://github.com/bitcoin/bips/blob/master/bip-0013.mediawiki), and [16](https://github.com/bitcoin/bips/blob/master/bip-0016.mediawiki), published by Andresen in 2011 and 2012, were all part of the addition of multisiganture transactions--also known as Pay to Script Hash or P2SH--to Bitcoin.
 
 ### Payment Protocol (BIP 70)
 
@@ -39,45 +38,45 @@ Andresen and Mike Hearn published [BIP 70](https://github.com/bitcoin/bips/blob/
 
 ## Bitcoin XT
 
-Andresen has long been critical of Bitcoin's capacity limit of three transactions per-second. He teamed up with Mike Hearn in an attempt to fork Bitcoin and created [Bitcoin XT](https://github.com/bitcoinxt/bitcoinxt). XT, also known as [BIP 101](https://github.com/bitcoin/bips/blob/master/bip-0101.mediawiki), proposed an immediate block size increase to 8 MB, which was to be doubled every two years. 
+Andresen has long been critical of Bitcoin's capacity limit of three transactions per-second. He teamed up with Mike Hearn in an attempt to fork Bitcoin and created [Bitcoin XT](https://github.com/bitcoinxt/bitcoinxt). XT, also known as [BIP 101](https://github.com/bitcoin/bips/blob/master/bip-0101.mediawiki), proposed an immediate block size increase to 8 MB, which was to be doubled every two years.
 
-Other Bitcoin developers were critical of Bitcoin XT and BIP 101. Some feared that large blocks could force small miners and nodes to shut down, leading to further centralization of Bitcoin. XT failed to reach consensus. Chinese mining pools, which control most of the Bitcoin network hash rate, also [rejected the proposal](http://cointelegraph.com/news/chinese-mining-pools-call-for-consensus-refuse-switch-to-bitcoin-xt). 
+Other Bitcoin developers were critical of Bitcoin XT and BIP 101. Some feared that large blocks could force small miners and nodes to shut down, leading to further centralization of Bitcoin. XT failed to reach consensus. Chinese mining pools, which control most of the Bitcoin network hash rate, also [rejected the proposal](http://cointelegraph.com/news/chinese-mining-pools-call-for-consensus-refuse-switch-to-bitcoin-xt).
 
 ## Bitcoin Classic
 
-After Bitcoin XT failed to achieve Andresen's goal of bumping the block size limit, he teamed up with another group of developers to create Bitcoin Classic. Classic proposed a more modest 2 MB block size increase via hardfork. 
+After Bitcoin XT failed to achieve Andresen's goal of bumping the block size limit, he teamed up with another group of developers to create Bitcoin Classic. Classic proposed a more modest 2 MB block size increase via hardfork.
 
-Bitcoin Classic received initial support from a number of miners--which are required to activate any block size increase via hard fork. A few weeks after Classic's release, however, the majority of Bitcoin miners [agreed to run](https://medium.com/@bitcoinroundtable/bitcoin-roundtable-consensus-266d475a61ff#.iz4wd5t59) only Bitcoin Core compatible software. 
+Bitcoin Classic received initial support from a number of miners--which are required to activate any block size increase via hard fork. A few weeks after Classic's release, however, the majority of Bitcoin miners [agreed to run](https://medium.com/@bitcoinroundtable/bitcoin-roundtable-consensus-266d475a61ff#.iz4wd5t59) only Bitcoin Core compatible software.
 
 ## Controversy
 
-Andresen is one of the most controversial figures in Bitcoin. Much of the controversy stems from his desire to increase Bitcoin's block size limit. 
+Andresen is one of the most controversial figures in Bitcoin. Much of the controversy stems from his desire to increase Bitcoin's block size limit.
 
-While most Bitcoin developers agree that Bitcoin must scale in order to accommodate more users, there is much debate about how to do so. Andresen proposals all aim to increase Bitcoin's capacity with hardforks via a block size increase. Other Bitcoin developers argue that a block size increase is unsafe and that more efficient methods exist to increase Bitcoin's capacity without a hardfork through proposals like [Segregated Witness](/what-are-segwit-benefits/). 
+While most Bitcoin developers agree that Bitcoin must scale in order to accommodate more users, there is much debate about how to do so. Andresen proposals all aim to increase Bitcoin's capacity with hardforks via a block size increase. Other Bitcoin developers argue that a block size increase is unsafe and that more efficient methods exist to increase Bitcoin's capacity without a hardfork through proposals like [Segregated Witness](/what-are-segwit-benefits/).
 
 ## Quotes
 
-[On SPV Mode](http://0bin.net/paste/8YeL12K5CwP26YUP#kSSLpZ2+PC9RqgcbiP0-bYbDhIHAMRCB3t2CpHkxokQ): 
+[On SPV Mode](http://0bin.net/paste/8YeL12K5CwP26YUP#kSSLpZ2+PC9RqgcbiP0-bYbDhIHAMRCB3t2CpHkxokQ):
 
 > I am willing to run SPV mode because I trust that my customers aren’t going to double spend against me.
 
-[On presenting hard fork risks](http://0bin.net/paste/8YeL12K5CwP26YUP#kSSLpZ2+PC9RqgcbiP0-bYbDhIHAMRCB3t2CpHkxokQ) the same as soft fork risks: 
+[On presenting hard fork risks](http://0bin.net/paste/8YeL12K5CwP26YUP#kSSLpZ2+PC9RqgcbiP0-bYbDhIHAMRCB3t2CpHkxokQ) the same as soft fork risks:
 
 > It doesn’t matter if the software is obsolete because of hard or soft fork, the difference in risks between those two cases will not be understood by the typical full node or SPV node user.
 
-[On the proper block size](https://twitter.com/gavinandresen/status/636569665284775937): 
+[On the proper block size](https://twitter.com/gavinandresen/status/636569665284775937):
 
 > I think 2MB is absurdly small.
 
-[On Peter Todd](https://www.reddit.com/r/Bitcoin/comments/2lypd1/peter_todd_on_changetip_not_a_real_bitcoin_app/clzd6yb): 
+[On Peter Todd](https://www.reddit.com/r/Bitcoin/comments/2lypd1/peter_todd_on_changetip_not_a_real_bitcoin_app/clzd6yb):
 
 > Peter is hung up on the decentralization/privacy aspects of Bitcoin
 
-[On using Bitcoins as a store of value](https://bitcointalk.org/index.php?topic=204.msg1714#msg1714): 
+[On using Bitcoins as a store of value](https://bitcointalk.org/index.php?topic=204.msg1714#msg1714):
 
 > I don’t plan on saving a significant number of Bitcoins as a store of value. I like to invest in people who are doing productive things that grow our economy and make the world a better place, so when Bitcoins replace dollars Wink I’ll lend them to people by buying bonds or stocks.
 
-[On no block limit](https://www.reddit.com/r/Bitcoin/comments/2ighvq/a_scalability_roadmap_the_bitcoin_foundation/cl2b7sg): 
+[On no block limit](https://www.reddit.com/r/Bitcoin/comments/2ighvq/a_scalability_roadmap_the_bitcoin_foundation/cl2b7sg):
 
 > In my heart of hearts I still believe that going back to “no hard-coded maximum block size” would work out just fine.
 
@@ -85,22 +84,22 @@ While most Bitcoin developers agree that Bitcoin must scale in order to accommod
 
 > Miners and merchants and wallet services and a small fraction of super-security-conscious people are more than enough for a robust, stable network; I don’t think we need more incentives to run full nodes.
 
-[On Peter Todd](https://www.reddit.com/r/Bitcoin/comments/28jp0y/why_is_peter_todd_wrecking_zeroconf_security/cibr8h2): 
+[On Peter Todd](https://www.reddit.com/r/Bitcoin/comments/28jp0y/why_is_peter_todd_wrecking_zeroconf_security/cibr8h2):
 
 > Peter Todd is a very large part of the “Bitcoin Core moves forward too slowly” problem.
 
-[On Peter Vesseness](https://www.reddit.com/r/Bitcoin/comments/1y9akl/mark_karpeles_petition_update/cfiwwyx) (who ran Bitcoin foundation and [stole 5 million](https://www.reddit.com/r/Bitcoin/comments/3y0ewr/forgotten_history_bitcoin_foundation_chairman/)): 
+[On Peter Vesseness](https://www.reddit.com/r/Bitcoin/comments/1y9akl/mark_karpeles_petition_update/cfiwwyx) (who ran Bitcoin foundation and [stole 5 million](https://www.reddit.com/r/Bitcoin/comments/3y0ewr/forgotten_history_bitcoin_foundation_chairman/)):
 
 > Peter is trustworthy.
 
-[On nodes in data centers](https://www.reddit.com/r/Bitcoin/comments/1scd4z/im_running_a_full_node_and_so_should_you/cdw3lrh): 
+[On nodes in data centers](https://www.reddit.com/r/Bitcoin/comments/1scd4z/im_running_a_full_node_and_so_should_you/cdw3lrh):
 
 > Most ordinary folks should NOT be running a full node. We need full nodes that are always on, have more than 8 connections (if you have only 8 then you are part of the problem, not part of the solution), and have a high-bandwidth connection to the Internet. So: if you’ve got an extra virtual machine with enough memory in a data center, then yes, please, run a full node.
 
-[On Peter Todd](https://www.reddit.com/r/Bitcoin/comments/1rqexb/87898_kb_block_just_now/cdpvh9x): 
+[On Peter Todd](https://www.reddit.com/r/Bitcoin/comments/1rqexb/87898_kb_block_just_now/cdpvh9x):
 
 > Maybe I don’t communicate clearly enough, but much of the fear, uncertainty, and doubt about the block size issue comes from people like Peter who want to know exactly how technical problems that MIGHT come up three years from now will be solved TODAY.
 
-[On respect](https://www.reddit.com/r/Bitcoin/comments/1oxn14/gavin_finally_lost_it/ccwqvwt): 
+[On respect](https://www.reddit.com/r/Bitcoin/comments/1oxn14/gavin_finally_lost_it/ccwqvwt):
 
 > Mmm. If you want my respect, write some code.

--- a/_people/gregory-maxwell-bitcoin-expert.md
+++ b/_people/gregory-maxwell-bitcoin-expert.md
@@ -1,8 +1,6 @@
 ---
 title: Gregory Maxwell
 seotitle: Gregory Maxwell - CTO, Blockstream
-published: true
-name: Gregory Maxwell
 position: CTO, Blockstream
 education:
 experience:

--- a/_people/gregory-maxwell-bitcoin-expert.md
+++ b/_people/gregory-maxwell-bitcoin-expert.md
@@ -4,15 +4,15 @@ seotitle: Gregory Maxwell - CTO, Blockstream
 published: true
 name: Gregory Maxwell
 position: CTO, Blockstream
-education: 
-experience: 
+education:
+experience:
 short_desc: Gregory Maxwell is a Bitcoin Core developer and Co-Founder and Chief Technology Officer of Blockstream.
-long_desc: 
+long_desc:
 affiliations: [Blockstream, Bitcoin Core]
-twitter: 
+twitter:
 github: gmaxwell
 residence:
-img: /images/gregory-maxwell.png 
+img: /images/gregory-maxwell.png
 cats: [bitcoin developer]
 ---
 Gregory Maxwell is a [Bitcoin Core](/bitcoin-core/) developer and Co-Founder and Chief Technology Officer of Blockstream.
@@ -23,7 +23,7 @@ Greg was one of the key architects of the two-way peg <a href="/what-are-sidecha
 
 ## Confidential Transactions
 
-Maxwell is currently working on [Confidential Transactions](https://people.xiph.org/~greg/confidential_values.txt) for Blockstream. Confidential Transactions will make transaction amounts visible to transaction participants and hide the data from the blockchain. 
+Maxwell is currently working on [Confidential Transactions](https://people.xiph.org/~greg/confidential_values.txt) for Blockstream. Confidential Transactions will make transaction amounts visible to transaction participants and hide the data from the blockchain.
 
 ## Bitcoin Development
 
@@ -43,10 +43,5 @@ A presentation on sidechains from the SF Bitcoin Dev Meetup:
 
 ## More Bitcoin Core Developers
 
-<div class="similar-people-wrap">
-{% for person in site.people %}
-{% if person.affiliations contains 'Bitcoin Core' and page.name != person.name %}
-{% include similar-people.html %}
-{% endif %}
-{% endfor %}
-</div>
+{% assign organization = page.affiliations[1] %}
+{% include similar-people.html organization=organization name=page.title %}

--- a/_people/jacob-dienelt.md
+++ b/_people/jacob-dienelt.md
@@ -1,24 +1,20 @@
 ---
 title: Jacob Dienelt
 seotitle: Jacob Dienelt - Blockchain Architect, itBit
-author: Jacob Dienelt
-authorurl: http://www.weusecoins.com
-published: true
-img: 
-name: Jacob Dienelt
+img:
 position: Treasurer, Factom Foundation
 education: Bsc. in Game Theory from Kenyon College
-experience: 
+experience:
 short_desc: Jacob Dienelt is Treasurer of The Factom Foundation and a Blockchain Architect at itBit.
-long_desc: 
+long_desc:
 affiliations: [itBit, Factom]
 twitter: jakedienelt
-github: 
-residence: 
+github:
+residence:
 cats: [ ]
 website: http://jacobdienelt.com/
 ---
-Jacob Dienelt is a Treasury Operations Expert, and is currently Treasurer of The [Factom](/factom/) Foundation and a Blockchain Architect at itBit. Jacob is also the founder of Immutable Data Partners, and advisor for several leading projects. 
+Jacob Dienelt is a Treasury Operations Expert, and is currently Treasurer of The [Factom](/factom/) Foundation and a Blockchain Architect at itBit. Jacob is also the founder of Immutable Data Partners, and advisor for several leading projects.
 
 ## History
 

--- a/_people/james-deangelo.md
+++ b/_people/james-deangelo.md
@@ -1,24 +1,20 @@
 ---
 title: James DeAngelo
 seotitle: James DeAngelo - Founder, World Bitcoin Network
-author: James DeAngelo
-authorurl: https://twitter.com/JamesGDAngelo
-published: true
 img: /images/james-deangelo.png
-name: James DeAngelo
 position: Founder, World Bitcoin Network
-education: 
-experience: 
+education:
+experience:
 short_desc: James DeAngelo is the Founder of World Bitcoin Network.
-long_desc: 
+long_desc:
 affiliations: [World Bitcoin Network]
 twitter: jamesgdangelo
-github: 
-residence: 
+github:
+residence:
 cats: featured
-website: 
+website:
 ---
-James De'Angelo is well-known in the Bitcoin industry for his YouTube Channel: [World Bitcoin Network](https://www.youtube.com/channel/UCgo7FCCPuylVk4luP3JAgVw/videos?view=0&flow=grid&sort=p). De'Angelo's videos provide simple explanations about basic Bitcoin concepts, making it easy for beginners to understand the new technology. 
+James De'Angelo is well-known in the Bitcoin industry for his YouTube Channel: [World Bitcoin Network](https://www.youtube.com/channel/UCgo7FCCPuylVk4luP3JAgVw/videos?view=0&flow=grid&sort=p). De'Angelo's videos provide simple explanations about basic Bitcoin concepts, making it easy for beginners to understand the new technology.
 
 ## Most Viewed Videos
 

--- a/_people/jeff-garzik.md
+++ b/_people/jeff-garzik.md
@@ -2,20 +2,19 @@
 title: Jeff Garzik
 seotitle: Jeff Garzik - Bitcoin Developer & Co-founder, Bloq
 img: /images/jeff-garzik.jpg
-name: Jeff Garzik
 position: Co-founder, Bloq
 education: B.S. in Computer Science from Georgia Institute of Technology
-experience: 
+experience:
 short_desc: Jeff Garzik is a Bitcoin core developer, CEO of Dunvegan Space Systems, Inc., and the Co-founder of Bloq.
-long_desc: 
+long_desc:
 affiliations: [Bitcoin Classic, Bloq]
-twitter: 
+twitter:
 github: jgarzik
-residence: 
+residence:
 cats: [ ]
 website: http://yyz.us/
 ---
-Jeff Garzik is a Bitcoin core developer, CEO of Dunvegan Space Systems, Inc., and the Co-founder of Bloq. He serves on [Coin Center's Board of Directors](https://coincenter.org/about/), and is an advisor to [BitPay](/bitpay/), BitFury, Chain, WayPaver Labs, and Netki. 
+Jeff Garzik is a Bitcoin core developer, CEO of Dunvegan Space Systems, Inc., and the Co-founder of Bloq. He serves on [Coin Center's Board of Directors](https://coincenter.org/about/), and is an advisor to [BitPay](/bitpay/), BitFury, Chain, WayPaver Labs, and Netki.
 
 ## BitPay
 
@@ -27,8 +26,8 @@ After leaving BitPay, Garzik founded Bloq in October 2015. According to [Bloq's 
 
 ## Bitcoin Classic
 
-Bitcoin Classic is an alternative implementation of Bitcoin that attempted a hard fork. Garzik is listed as a developer on [Bitcoin Classic's website](https://bitcoinclassic.com/){:rel="nofollow"}, but hasn't submitted any code publicly aside from a [pull request to change the hard for activation threshold](https://github.com/bitcoinclassic/bitcoinclassic/pull/60). 
+Bitcoin Classic is an alternative implementation of Bitcoin that attempted a hard fork. Garzik is listed as a developer on [Bitcoin Classic's website](https://bitcoinclassic.com/){:rel="nofollow"}, but hasn't submitted any code publicly aside from a [pull request to change the hard for activation threshold](https://github.com/bitcoinclassic/bitcoinclassic/pull/60).
 
 ## BIP 100
 
-Garzik proposed [BIP 100](http://gtf.org/garzik/bitcoin/BIP100-blocksizechangeproposal.pdf), and it initially received positive feedback from miners. No supporting code was released after it became clear that it was unlikely to be adopted. 
+Garzik proposed [BIP 100](http://gtf.org/garzik/bitcoin/BIP100-blocksizechangeproposal.pdf), and it initially received positive feedback from miners. No supporting code was released after it became clear that it was unlikely to be adopted.

--- a/_people/jeremy-gardner.md
+++ b/_people/jeremy-gardner.md
@@ -2,18 +2,17 @@
 title: Jeremy Gardner
 img: /images/jeremy-gardner.png
 seotitle: Jeremy Gardner - Co-Founder, BlockchainEdu
-name: Jeremy Gardner
 position: Founder, BlockchainEdu
-education: 
+education:
 experience: 
-short_desc: Jeremy Gardner is the Co-Founder of BlockchainEdu and Augur. 
-long_desc: 
+short_desc: Jeremy Gardner is the Co-Founder of BlockchainEdu and Augur.
+long_desc:
 affiliations: [BlockchainEdu, Augur]
 twitter: disruptepreneur
-github: 
-residence: 
+github:
+residence:
 cats: [ ]
-website: 
+website:
 ---
 I have seemingly dedicated my life to cryptocurrencies and block chain technology over the course of the past year. I am the co-founder and executive director of the College Cryptocurrency Network (CCN), Director of Operations/Business Development at Augur, and serve as an official advisor to Bitcoin Shop.
 

--- a/_people/jesse-powell.md
+++ b/_people/jesse-powell.md
@@ -2,16 +2,15 @@
 title: Jesse Powell
 seotitle: Jesse Powell - CEO of Kraken
 img: /images/jesse-powell.png 
-name: Jesse Powell
 position: CEO of Kraken
-education: 
-experience: 
+education:
+experience:
 short_desc: Jesse Powell is the co-founder and CEO of Kraken.
-long_desc: 
+long_desc:
 affiliations: [Kraken]
 twitter: jespow
-github: 
-residence: 
+github:
+residence:
 cats: [ ]
 website: http://jesse.forthewin.com/
 ---

--- a/_people/joaquin-moreno.md
+++ b/_people/joaquin-moreno.md
@@ -1,20 +1,17 @@
 ---
 title: Joaquin Moreno
-author: Joaquin Moreno
-authorurl: http://www.weusecoins.com/joaquin-moreno/
-published: true
 seotitle: Joaquin Moreno - Founder, Mondome
 img: /images/joaquin-moreno.png
 name: Joaquin Moreno
 position: Founder, Mondome
-education: 
-experience: 
-short_desc: Joaquin Moreno is the founder of Mondome and BTC en Español. 
-long_desc: 
+education:
+experience:
+short_desc: Joaquin Moreno is the founder of Mondome and BTC en Español.
+long_desc:
 affiliations: [Mondome, BTC en Español]
 twitter: joaquinmoreno
-github: 
-residence: 
+github:
+residence:
 cats: [ ]
 website: http://btcenespanol.com/
 ---

--- a/_people/joel-pobeda.md
+++ b/_people/joel-pobeda.md
@@ -2,20 +2,19 @@
 title: Joel Pobeda
 seotitle: Joel Pobeda - COO, Ledger
 img: /images/joel-pobeda.png
-name: Joel Pobeda
 position: COO, Ledger
-education: 
-experience: 
+education:
+experience:
 short_desc: Joel Pobeda is the Co-founder and COO of Ledger.
-long_desc: 
+long_desc:
 affiliations: [Ledger, Chronocoin]
-twitter: 
-github: 
-residence: 
+twitter:
+github:
+residence:
 cats: [ ]
-website: 
+website:
 ---
-Joel Pobeda is the Co-founder and COO of [Ledger](/ledger/), a Bitcoin security company. 
+Joel Pobeda is the Co-founder and COO of [Ledger](/ledger/), a Bitcoin security company.
 
 ## Chronocoin
 

--- a/_people/john-rubino.md
+++ b/_people/john-rubino.md
@@ -1,12 +1,9 @@
 ---
 title: John Rubino
-author: John Rubino
-authorurl: http://www.dollarcollapse.com
-published: true
 ---
 <img src="/images/john-rubino.png" alt="John Rubino" align="right">
 
-Co-authored The Money Bubble (DollarCollapse Press, 2014) and <a href="http://www.runtogold.com/thecollapseofthedollarbook">The Collapse of the Dollar and How to Profit From It</a> (Doubleday, 2007), and author of Clean Money: Picking Winners in the Green-Tech Boom (Wiley, 2008), 
+Co-authored The Money Bubble (DollarCollapse Press, 2014) and <a href="http://www.runtogold.com/thecollapseofthedollarbook">The Collapse of the Dollar and How to Profit From It</a> (Doubleday, 2007), and author of Clean Money: Picking Winners in the Green-Tech Boom (Wiley, 2008),
 How to Profit from the Coming Real Estate Bust (Rodale, 2003) and Main Street, Not Wall Street (Morrow, 1998).
 
 <iframe width="700" height="394" src="https://www.youtube.com/embed/NKMPZAlsAOk" frameborder="0" allowfullscreen></iframe>

--- a/_people/john-velissarios-bitcoin-security-expert.md
+++ b/_people/john-velissarios-bitcoin-security-expert.md
@@ -1,22 +1,18 @@
 ---
 title: John Velissarios - Bitcoin Security Expert
-author: John Velissarios
-authorurl: https://www.weusecoins.com/john-velissarios-bitcoin-security-expert
-published: true
 seotitle: John Velissarios
 img: /images/john-velissarios.png
-name: John Velissarios
 position: Consultant
 education: Degree in Computer Science & Graduate Degree in Cryptography and Information Security
-experience: 
+experience:
 short_desc: John Velissarios provides security consulting services for blockchain and Bitcoin technologies.
-long_desc: 
+long_desc:
 affiliations: [Accenture]
-twitter: 
-github: 
+twitter:
+github:
 residence: [London]
 cats: [ ]
-website: 
+website:
 ---
 John spearheads the professional global services division. He brings two decades of IT security expertise earned in the world’s most trusted consulting organizations and was entrusted with protecting the world's most important and valuable private keys. He served a global customer base of tier 1 financial institutions and payment processors.
 
@@ -26,6 +22,6 @@ He leads the blockchain and Bitcoin security consulting services.
 
 John holds a degree in computer science and graduate degree in cryptography and information security. John is a founding member of the Institute of Information Security Professionals, IISP, and regular speaker at security conferences.
 
-## Video 
+## Video
 
 <center><iframe width="700" height="394" src="https://www.youtube.com/embed/Y1WRH0Pomlg" frameborder="0" allowfullscreen></iframe></center>

--- a/_people/jonas-schnelli.md
+++ b/_people/jonas-schnelli.md
@@ -2,16 +2,15 @@
 title: Jonas Schnelli
 seotitle: Jonas Schnelli - Bitcoin Core Developer
 img: /images/jonas-schnelli.png
-name: Jonas Schnelli
 position: Co-founder, Digital Bitbox
-education: 
-experience: 
-short_desc: Jonas Schnelli is a Bitcoin Core developer and the co-founder of Digital Bitbox. 
-long_desc: 
+education:
+experience:
+short_desc: Jonas Schnelli is a Bitcoin Core developer and the co-founder of Digital Bitbox.
+long_desc:
 affiliations: [Bitcoin Core, Digital Bitbox]
 twitter: _jonasschnelli_
 github: jonasschnelli
-residence: 
+residence:
 cats: [ ]
 website:  
 ---
@@ -23,7 +22,7 @@ Schnelli submitted his first line of code to Bitcoin Core in April 2013 and is #
 
 ## Digital Bitbox
 
-Schnelli is the co-founder of [Digital Bitbox](https://digitalbitbox.com/), a minimalist Bitcoin hardware wallet that has yet to be released. 
+Schnelli is the co-founder of [Digital Bitbox](https://digitalbitbox.com/), a minimalist Bitcoin hardware wallet that has yet to be released.
 
 ## Quotes
 
@@ -31,16 +30,16 @@ On [confirmations](https://bitcoinmagazine.com/articles/bitcoin-core-developer-j
 
 > 0-confirmation by Satoshi’s whitepaper was always insecure, but because people have built systems on it, we have to make sure that it’s stable, that people can buy stuff instantly. I mean, you can’t wait ten minutes when you pay for a coffee; I agree.
 
-On [Segregated Witness and hardforks](https://bitcoinmagazine.com/articles/core-developer-jonas-schnelli-segregated-witness-improves-and-optimizes-bitcoin-protocol-1454517960): 
+On [Segregated Witness and hardforks](https://bitcoinmagazine.com/articles/core-developer-jonas-schnelli-segregated-witness-improves-and-optimizes-bitcoin-protocol-1454517960):
 
 > A 2-megabyte hard fork does not improve the protocol itself, not a tiny bit. With Segregated Witness, we have a chance to get a ‘better,’ more optimized protocol, and reach almost the same amount of transactions per block. And, extremely important, Segregated Witness has almost full consensus.
 
-On hardforks: 
+On hardforks:
 
 > I personally cannot understand why some developers are still thinking that a 2- megabyte hard fork is preferable. The main risks of a hard fork are not technical, but there are huge risks of disrupting the whole Bitcoin economy. The Bitcoin market is extremely fragile, and it fully trusts in developer consensus. Bitcoin is still very young. If we start fighting and disagree on the very deepest technical layer, we hurt Bitcoin in its core and will lose irreplaceable trust from the markets.
 
 ## Video
 
-Schnelli explains what's new in Bitcoin Core 0.12: 
+Schnelli explains what's new in Bitcoin Core 0.12:
 
 <iframe width="640" height="360" src="https://www.youtube.com/embed/RWeIEFBrItE" frameborder="0" allowfullscreen></iframe>

--- a/_people/jordan-tuwiner.md
+++ b/_people/jordan-tuwiner.md
@@ -2,19 +2,18 @@
 title: Jordan Tuwiner
 img: /images/jordan-tuwiner.png
 seotitle: Jordan Tuwiner - Founder, Buy Bitcoin Worldwide
-name: Jordan Tuwiner
 position: Founder, Buy Bitcoin Worldwide
-education: 
-experience: 
+education:
+experience:
 short_desc: Jordan Tuwiner is the founder of Buy Bitcoin Worldwide.
-long_desc: 
+long_desc:
 affiliations: [Buy Bitcoin Worldwide]
 twitter: jordantuwiner
 github: JTuwiner
-residence: 
+residence:
 cats: [ ]
 website: https://www.jordantuwiner.com/
 ---
-Jordan Tuwiner is the founder of [Buy Bitcoin Worldwide](https://www.buybitcoinworldwide.com/), where he helps the world buy bitcoin. Additionally, he created [Cold Hardware](https://www.coldhardware.com/), where he helps users learn about the benefits of using hardware wallets for cold storage. 
+Jordan Tuwiner is the founder of [Buy Bitcoin Worldwide](https://www.buybitcoinworldwide.com/), where he helps the world buy bitcoin. Additionally, he created [Cold Hardware](https://www.coldhardware.com/), where he helps users learn about the benefits of using hardware wallets for cold storage.
 
 Jordan is also a Bitcoin proponent, hoarder, and contributor at We Use Coins. He's excited to see benefits sound money will bring to society.

--- a/_people/josh-crumb.md
+++ b/_people/josh-crumb.md
@@ -1,22 +1,18 @@
 ---
 title: Josh Crumb
-author: Josh Crumb - CSO Bitgold
-authorurl: /josh-crumb/
-published: true
 seotitle: Josh Crumb - CSO Bitgold
 img: /images/josh-crumb.png
-name: Josh Crumb
 position: CSO Bitgold
 education: Master of Science degree in Mineral Economics, Bachelor of Science degree in Engineering from the Colorado School of Mines
-experience: 
+experience:
 short_desc: Josh Crumb is the co-founder and Chief Strategy Officer of BitGold.
-long_desc: 
+long_desc:
 affiliations: [Bitgold]
-twitter: 
-github: 
-residence: 
+twitter:
+github:
+residence:
 cats: [ ]
-website: 
+website:
 ---
 Josh Crumb is the co-founder and Chief Strategy Officer of <a href="/bitgold/">BitGold</a>.
 
@@ -39,10 +35,5 @@ He holds a Master of Science degree in Mineral Economics, a Graduate Certificate
 
 ## BitGold Executive Management Team Members
 
-<div class="similar-people-wrap">
-{% for person in site.people %}
-{% if person.affiliations contains 'BitGold' and page.name != person.name %}
-{% include similar-people.html %}
-{% endif %}
-{% endfor %}
-</div>
+{% assign organization = page.affiliations[0] %}
+{% include similar-people.html organization=organization name=page.title %}

--- a/_people/katy-millington.md
+++ b/_people/katy-millington.md
@@ -1,20 +1,17 @@
 ---
 title: Katy Millington
-author: Katy Millington - General Counsel of Bitgold
-seotitle: Katy Millington - General Counsel of Bitgold
-authorurl: /katy-millington/
 published: true
 img: /images/katy-millington.png
-name: Katy Millington
 position: General Counsel of Bitgold
 education: Bachelor of Laws & Bachelor of Arts from the University of Auckland
-experience: 
+experience:
 short_desc: Katy Millington is the group General Counsel of BitGold.
-long_desc: 
-affiliations: BitGold
+long_desc:
+affiliations:
+  - BitGold
 twitter: katybmillington
-github: 
-residence: 
+github:
+residence:
 ---
 Katy Millington is the group General Counsel of BitGold, an executive director of the Jersey companies, and the Jersey Head of Compliance.
 
@@ -34,10 +31,5 @@ She holds a Bachelor of Laws (with honours) and a Bachelor of Arts from the Univ
 
 ## BitGold Executive Management Team Members
 
-<div class="similar-people-wrap">
-{% for person in site.people %}
-{% if person.affiliations contains 'BitGold' and page.name != person.name %}
-{% include similar-people.html %}
-{% endif %}
-{% endfor %}
-</div>
+{% assign organization = page.affiliations[0] %}
+{% include similar-people.html organization=organization name=page.title %}

--- a/_people/luke-dashjr.md
+++ b/_people/luke-dashjr.md
@@ -2,16 +2,15 @@
 title: Luke Dashjr (Luke-Jr)
 seotitle: Luke Dashjr (Luke-Jr) - Bitcoin Core Developer
 img: /images/luke-dashjr.png
-name: Luke Dashjr
-position: Bitcoin Core Developer 
-education: 
-experience: 
-short_desc: Luke Dashjr is a Bitcoin Core developer and founder of Eligius mining pool. 
-long_desc: 
+position: Bitcoin Core Developer
+education:
+experience:
+short_desc: Luke Dashjr is a Bitcoin Core developer and founder of Eligius mining pool.
+long_desc:
 affiliations: [Bitcoin Core, BFG Miner]
-twitter: 
+twitter:
 github: luke-jr
-residence: 
+residence:
 cats: [ ]
 website: http://luke.dashjr.org/
 ---
@@ -33,17 +32,12 @@ Dashjr founded [Eligius](http://eligius.st/~gateway/), one of the first Bitcoin 
 
 ## BIPs 22 & 23
 
-Dashjr is responsible for BIPs [22](https://github.com/bitcoin/bips/blob/master/bip-0022.mediawiki) and [23](https://github.com/bitcoin/bips/blob/master/bip-0023.mediawiki). 
+Dashjr is responsible for BIPs [22](https://github.com/bitcoin/bips/blob/master/bip-0022.mediawiki) and [23](https://github.com/bitcoin/bips/blob/master/bip-0023.mediawiki).
 
 BIP 22 added protocol support for long polling, which allowed to be notified of new templates immediately. BIP 23 [allows miners](https://bitcointalk.org/index.php?topic=957509.0) to "check the basic validity of their next block before expending work on it, reducing risks of accidental
 hardforks or mining invalid blocks."
 
 ## More Bitcoin Core Developers
 
-<div class="similar-people-wrap">
-{% for person in site.people %}
-{% if person.affiliations contains 'Bitcoin Core' and page.name != person.name %}
-{% include similar-people.html %}
-{% endif %}
-{% endfor %}
-</div>
+{% assign organization = page.affiliations[0] %}
+{% include similar-people.html organization=organization name=page.title %}

--- a/_people/marcus-of-augustus.md
+++ b/_people/marcus-of-augustus.md
@@ -1,8 +1,6 @@
 ---
-title: Marcus of Augustus - Bitcoin Core Developer
-author: Marcus of Augustus
-authorurl: https://www.weusecoins.com/marcus-of-augustus/
-published: true
+title: Marcus of Augustus
+seotitle: Marcus of Augustus - Bitcoin Core Developer
 ---
 
 About Marcus of Augustus. Core Bitcoin developer.

--- a/_people/mark-friedenbach.md
+++ b/_people/mark-friedenbach.md
@@ -2,25 +2,24 @@
 title: Mark Friedenbach
 seotitle: Mark Friedenbach - Co-founder, Blockstream
 img: /images/mark-friedenbach.jpg
-name: Mark Friedenbach
 position: Co-founder, Blockstream
 education: B.S. in Engineering Physics from Santa Clara University
-experience: 
+experience:
 short_desc: Mark Friedenbach is a Co-founder of Blockstream.
-long_desc: 
+long_desc:
 affiliations: [Bitcoin Core, Blockstream]
 twitter: markfriedenbach
 github: maaku
-residence: 
+residence:
 cats: [ ]
-website: 
+website:
 ---
-Mark Friedenbach is a Co-founder of [Blockstream](/blockstream/). Previously, [he worked](https://www.linkedin.com/in/markfriedenbach) as an Application Developer at NASA-Ames Research Center. 
+Mark Friedenbach is a Co-founder of [Blockstream](/blockstream/). Previously, [he worked](https://www.linkedin.com/in/markfriedenbach) as an Application Developer at NASA-Ames Research Center.
 
 ## BIPs
 
-Friedenbach has contributed code based on three Bitcoin Improvement Proposals (BIPs): [BIP 68](https://github.com/bitcoin/bips/blob/master/bip-0068.mediawiki), [BIP 112](https://github.com/bitcoin/bips/blob/master/bip-0112.mediawiki), and [BIP 113](https://github.com/bitcoin/bips/blob/master/bip-0113.mediawiki). 
+Friedenbach has contributed code based on three Bitcoin Improvement Proposals (BIPs): [BIP 68](https://github.com/bitcoin/bips/blob/master/bip-0068.mediawiki), [BIP 112](https://github.com/bitcoin/bips/blob/master/bip-0112.mediawiki), and [BIP 113](https://github.com/bitcoin/bips/blob/master/bip-0113.mediawiki).
 
-BIPs 68, 112, and 113 all make improvements to the Bitcoin protocol which are required for [Lightning Network](/adam-back-lightning-network/). 
+BIPs 68, 112, and 113 all make improvements to the Bitcoin protocol which are required for [Lightning Network](/adam-back-lightning-network/).
 
-The code for all three BIPs will be deployed on May 1, 2016. 
+The code for all three BIPs will be deployed on May 1, 2016.

--- a/_people/matias-bari.md
+++ b/_people/matias-bari.md
@@ -1,25 +1,24 @@
 ---
 title: Matias Bari
-seotitle: Matias Bari - CEO, SatoshiTango 
+seotitle: Matias Bari - CEO, SatoshiTango
 img: /images/matias-bari.png
-name: Matias Bari
 position: CEO, SatoshiTango
-education: 
-experience: 
+education:
+experience:
 short_desc: Matias Bari is the CEO of SatoshiTango.  
-long_desc: 
+long_desc:
 affiliations: [SatoshiTango]
-twitter: 
-github: 
-residence: 
+twitter:
+github:
+residence:
 cats: [ ]
-website: 
+website:
 ---
-Matias Bari is the CEO of [SatoshiTango](https://satoshitango.com/home), a Bitcoin platform and exchange. SatoshiTango allows users to [buy and sell bitcoins](/en/how-buy-bitcoins-online-best-bitcoin-exchange-rate-bitcoin-price/), [spend bitcoins](/what-can-you-buy-with-bitcoin/) through a VISA debit card, or top-up mobile phones. 
+Matias Bari is the CEO of [SatoshiTango](https://satoshitango.com/home), a Bitcoin platform and exchange. SatoshiTango allows users to [buy and sell bitcoins](/en/how-buy-bitcoins-online-best-bitcoin-exchange-rate-bitcoin-price/), [spend bitcoins](/what-can-you-buy-with-bitcoin/) through a VISA debit card, or top-up mobile phones.
 
-## Coinnect 
+## Coinnect
 
-Bari, in a partnership with Mexican Bitcoin exchange Volabit, [launched Coinnect](http://www.coindesk.com/volabit-satoshitango-rebittance-argentina-mexico/). It allows users to send remittances from SatoshiTango to Volabit--or vice-versa--without the need to know what Bitcoin is or how to use it. 
+Bari, in a partnership with Mexican Bitcoin exchange Volabit, [launched Coinnect](http://www.coindesk.com/volabit-satoshitango-rebittance-argentina-mexico/). It allows users to send remittances from SatoshiTango to Volabit--or vice-versa--without the need to know what Bitcoin is or how to use it.
 
 ## Links
 
@@ -28,7 +27,7 @@ Bari, in a partnership with Mexican Bitcoin exchange Volabit, [launched Coinnect
 
 ## Quotes
 
-On why SatoshiTango [sells bitcoins through pre-paid cards](http://www.coindesk.com/bootstrapping-bitcoin-startup-amid-argentinas-financial-uncertainty/): 
+On why SatoshiTango [sells bitcoins through pre-paid cards](http://www.coindesk.com/bootstrapping-bitcoin-startup-amid-argentinas-financial-uncertainty/):
 
 > We believe that if people are familiar with prepaid cards, why not use these? People are very happy because they understand when they buy a prepaid card, the card is ready to buy bitcoin, and the exact amount they have in their hands is what they can buy.
 

--- a/_people/melanie-shapiro.md
+++ b/_people/melanie-shapiro.md
@@ -2,33 +2,32 @@
 title: Melanie Shapiro
 seotitle: Melanie Shapiro - CEO, Case
 img: /images/melanie-shapiro.jpg
-name: Melanie Shapiro
 position: CEO, Case
 education: PhD in Consumer Behavior from The University of Reading
-experience: 
+experience:
 short_desc: Melanie Shapiro is the Founder and CEO of Case.
-long_desc: 
+long_desc:
 affiliations: [Case]
 twitter: melshapiro
-github: 
-residence: 
+github:
+residence:
 cats: [ ]
-website: 
+website:
 ---
 Melanie Shapiro is the Founder and CEO of [Case](/case/), a multisignature Bitcoin hardware wallet.
 
-Previously, she served as the Director of Marketing at Kleverbeast, and worked in Research for Microsoft. 
+Previously, she served as the Director of Marketing at Kleverbeast, and worked in Research for Microsoft.
 
 ## Quotes
 
-On how Case [is different from Trezor](http://www.coindesk.com/cryptolabs-announces-multisig-hardware-wallet-biometric-authentication/): 
+On how Case [is different from Trezor](http://www.coindesk.com/cryptolabs-announces-multisig-hardware-wallet-biometric-authentication/):
 
 > The difference is that this is an actual wallet. You can take it with you. Trezor has to be plugged into your computer for you to use it. This plugs into nothing.
 
-On [Case's purpose](http://www.coindesk.com/bitcoin-hardware-wallet-case-raises-2-25-million-in-funding/): 
+On [Case's purpose](http://www.coindesk.com/bitcoin-hardware-wallet-case-raises-2-25-million-in-funding/):
 
 > Bitcoin and other distributed ledger technologies facilitate the transfer of digital financial assets within cryptographically secured, immutable environments. Case acts as a secure signing device that streamlines this process without increasing the risk of compromising sensitive data.
 
-## Video 
+## Video
 
 <iframe width="740" height="416" src="https://www.youtube.com/embed/ZSSuHkxtf7I?rel=0" frameborder="0" allowfullscreen></iframe>

--- a/_people/michael-perklin-bitcoin-security-expert.md
+++ b/_people/michael-perklin-bitcoin-security-expert.md
@@ -1,22 +1,18 @@
 ---
 title: Michael Perklin
-author: Michael Perklin
-authorurl: https://www.weusecoins.com/michael-perklin-bitcoin-security-expert
-published: true
 seotitle: Michael Perklin - Bitcoin Security Expert
 img: /images/michael-perklin.png
-name: Michael Perklin
 position: 
-education: 
-experience: 
-short_desc: Michael Perklin is the president of C4 and Bitcoinsultants, and the Chairman of the Board at Bitcoin Alliance of Canada. 
-long_desc: 
+education:
+experience:
+short_desc: Michael Perklin is the president of C4 and Bitcoinsultants, and the Chairman of the Board at Bitcoin Alliance of Canada.
+long_desc:
 affiliations: [C4, Bitcoin Alliance of Canada, Bitcoinsultants]
 twitter: mperklin
-github: 
-residence: 
+github:
+residence:
 cats: [ ]
-website: 
+website:
 ---
 I am a cybersecurity expert who has worked for over a decade in the information security space. In the past I've held positions as a cyber investigator, a digital-forensic investigator, a reverse engineer, an application tester, and a computer programmer.
 

--- a/_people/nic-cary.md
+++ b/_people/nic-cary.md
@@ -2,20 +2,19 @@
 title: Nicolas Cary
 seotitle: Nic Cary - Co-Founder, Blockchain
 img: /images/nic-cary.jpg
-name: Nic Cary
 position: Co-Founder, Blockchain
-education: 
-experience: 
-short_desc: Nic Cary is the Co-founder of Blockchain. 
-long_desc: 
+education:
+experience:
+short_desc: Nic Cary is the Co-founder of Blockchain.
+long_desc:
 affiliations: [Blockchain, ZeroBlock]
 twitter: niccary
-github: 
-residence: 
+github:
+residence:
 cats: [ ]
 website: https://nicolascary.com/
 ---
-Nicolas Cary is a co-founder of Blockchain, a popular Bitcoin block explorer and [Bitcoin wallet](/en/find-the-best-bitcoin-wallet/). He also co-founded [Youth Business USA](https://twitter.com/YouthBusinessUS), a nonprofit that supports and trains young entrepreneurs. 
+Nicolas Cary is a co-founder of Blockchain, a popular Bitcoin block explorer and [Bitcoin wallet](/en/find-the-best-bitcoin-wallet/). He also co-founded [Youth Business USA](https://twitter.com/YouthBusinessUS), a nonprofit that supports and trains young entrepreneurs.
 
 ## Links
 
@@ -24,7 +23,7 @@ Nicolas Cary is a co-founder of Blockchain, a popular Bitcoin block explorer and
 
 ## Quotes
 
-On [Bitcoin's future](http://www.newsweek.com/bitcoin-too-big-fail-418481): 
+On [Bitcoin's future](http://www.newsweek.com/bitcoin-too-big-fail-418481):
 
 > The Bitcoin blockchain will catalyze innovation over the coming years. As citizens of the internet we demand transparency and ease of use. In 2016 people expect to be able to send money over the internet as quickly and cheaply as sending an email. The fact that it still takes several days to send an international money transfer is a throwback to yesteryear. Bitcoin solves that problem.
 

--- a/_people/nicola-minichiello.md
+++ b/_people/nicola-minichiello.md
@@ -1,24 +1,20 @@
 ---
 title: Nicola Minichiello
-author: Nicola Minichiello
-authorurl: https://www.weusecoins.com/nicola-minichiello/
-published: true
 seotitle: Nicola Minichiello - Community Director, Factom
 img: /images/nicola-minichiello.png
-name: Nicola Minichiello
 position: Community Director, Factom
-education: 
-experience: 
+education:
+experience:
 short_desc: Nicola Minichiello is the Community Director of Factom.
-long_desc: 
+long_desc:
 affiliations: [Factom, Storj, Swarm]
 twitter: colortwits
-github: 
-residence: 
+github:
+residence:
 cats: [ ]
-website: 
+website:
 ---
-Nicola Minichiello (Nic) is originally Italian but relocated to London, UK 18 years ago where he works and lives since. Born to get things done, he is an experienced “factotum”, skilled and proficient in many fields. He is currently a VP of Marketing and Communications, a Community Director, a Project and Operations Manager, for some of the top Bitcoin 2.0 projects. 
+Nicola Minichiello (Nic) is originally Italian but relocated to London, UK 18 years ago where he works and lives since. Born to get things done, he is an experienced “factotum”, skilled and proficient in many fields. He is currently a VP of Marketing and Communications, a Community Director, a Project and Operations Manager, for some of the top Bitcoin 2.0 projects.
 
 Nic is an active team member at [Storj](http://storj.io), [Factom](http://factom.org), [Synereo](http://synereo.com), [Swarm](http://swarm.fund), [Vanbex Group](http://vanbex.com), and collaborates on a number of other projects. He is a Senior Technology Specialist at the Financial Times where he has worked for over 15 years. An Apple Certified Technical Coordinator with experience in Data Center, Cloud Computing, Video Production, Data Storage, and Media Asset Management. Nic studied Computer Science at the University of Pisa, Italy.
 
@@ -47,10 +43,10 @@ Nic is an active team member at [Storj](http://storj.io), [Factom](http://factom
 
 <a href="http://factom.org" align="left" target="_blank"><img
  src="/images/factom_logo_small.png" alt="Factom"
- style="border: 0px solid ; width: 200px;"></a> 
+ style="border: 0px solid ; width: 200px;"></a>
  <a href="http://synereo.com" align="middle" target="_blank"><img
  src="/images/synereo_logo.png" alt="Synereo"
- style="border: 0px solid ; width: 200px;"></a> 
+ style="border: 0px solid ; width: 200px;"></a>
  <a href="http://vanbex.com" align="right" target="_blank"><img
  src="/images/vanbexgroup_logo.png" alt="Vanbex Group"
  style="border: 0px solid ; width: 200px;"></a>
@@ -62,7 +58,7 @@ Nic is an active team member at [Storj](http://storj.io), [Factom](http://factom
  style="border: 0px solid ; width: 150px;"></a> <a href="http://ft.com" align="right" target="_blank"><img
  src="/images/ft_logo.png"  alt="Financial Times"
  style="border: 0px solid ; width: 150px;"></a>
- 
+
 
 ### Bitcoin articles by Nicola Minichiello
 

--- a/_people/nicolas-bacca.md
+++ b/_people/nicolas-bacca.md
@@ -2,25 +2,24 @@
 title: Nicolas Bacca
 seotitle: Nicolas Bacca - CTO, Ledger
 img: /images/nicolas-bacca.png
-name: Nicolas Bacca
 position: CTO, Ledger
-education: 
-experience: 
+education:
+experience:
 short_desc: Nicolas Bacca is the founder of BTChip and the CTO of Ledger.
-long_desc: 
+long_desc:
 affiliations: [Ledger, BTChip]
 twitter: btchip
 github: btchip
-residence: 
+residence:
 cats: [ ]
-website: 
+website:
 ---
-Nicolas Bacca is the founder of BTChip and the CTO of [Ledger](/ledger/). 
+Nicolas Bacca is the founder of BTChip and the CTO of [Ledger](/ledger/).
 
 ## BTChip
 
-Bacca founded [BTChip](https://hardwarewallet.com/), which was the first Bitcoin hardware wallet. In 2014, BTChip merged with La Maison du Bitcoin and Chronocoin to become Ledger. 
+Bacca founded [BTChip](https://hardwarewallet.com/), which was the first Bitcoin hardware wallet. In 2014, BTChip merged with La Maison du Bitcoin and Chronocoin to become Ledger.
 
 ## Experience
 
-In 2009, Bacca founded Simulity, an embedded communications software company. He also served on the Cards & Solutions Innovation team at Oberthur Technologies. 
+In 2009, Bacca founded Simulity, an embedded communications software company. He also served on the Cards & Solutions Innovation team at Oberthur Technologies.

--- a/_people/nik-costodia.md
+++ b/_people/nik-costodia.md
@@ -1,22 +1,19 @@
 ---
 title: Nik Costodia
-author: Nik Costodia
-authorurl: https://www.weusecoins.com/nik-costodia/
-published: true
 seotitle: Nik Costodia - Senior Director, FTI Consulting / UX
 img: /images/nik-costodia.jpg
 name: Nik Costodia
 position: Senior Director, FTI Consulting / UX
-education: 
-experience: 
-short_desc: 
-long_desc: 
+education:
+experience:
+short_desc:
+long_desc:
 affiliations: []
 twitter: nik5ter
-github: 
-residence: 
+github:
+residence:
 cats: [ ]
-website: 
+website:
 ---
 
 Nik Custodio (@nik5ter) is a Director at FTI Consulting / UX.

--- a/_people/nimrod-lehavi.md
+++ b/_people/nimrod-lehavi.md
@@ -2,19 +2,18 @@
 title: Nimrod Lehavi
 seotitle: Nimrod Lehavi - CEO, Simplex
 img: /images/nimrod-lehavi.png
-name: Nimrod Lehavi
 position: CEO, Simplex
-education: 
-experience: 
+education:
+experience:
 short_desc: Nimrod Lehavi is the CEO and Co-founder of Simplex.
-long_desc: 
+long_desc:
 affiliations: [Simplex, Israeli Bitcoin Association]
 twitter: nimrodlehavi
-github: 
-residence: 
+github:
+residence:
 cats: [ ]
-website: 
+website:
 ---
-Nimrod Lehavi is the CEO and Co-founder of [Simplex](/simplex/), a credit card fraud prevention company. In addition, he's a Board Member of the Israeli Bitcoin Association. 
+Nimrod Lehavi is the CEO and Co-founder of [Simplex](/simplex/), a credit card fraud prevention company. In addition, he's a Board Member of the Israeli Bitcoin Association.
 
-Previously, he founded Lehavi Solutions Software Boutique, which provides enterprise technology solutions. 
+Previously, he founded Lehavi Solutions Software Boutique, which provides enterprise technology solutions.

--- a/_people/pablo-gonzalez.md
+++ b/_people/pablo-gonzalez.md
@@ -2,20 +2,19 @@
 title: Pablo Gonzalez
 seotitle: Pablo Gonzalez - CEO, Bitso
 img: /images/pablo-gonzalez.jpg
-name: Pablo Gonzalez
 position: CEO, Bitso
-education: 
-experience: 
+education:
+experience:
 short_desc: Pablo Gonzalez is the CEO of Bitso.
-long_desc: 
+long_desc:
 affiliations: [Bitso]
 twitter: pablo_gonzalez
-github: 
-residence: 
+github:
+residence:
 cats: [ ]
-website: 
+website:
 ---
-Pablo Gonzalez is the CEO of Mexican Bitcoin exchange Bitso. 
+Pablo Gonzalez is the CEO of Mexican Bitcoin exchange Bitso.
 
 ## Links
 

--- a/_people/paul-rosenberg.md
+++ b/_people/paul-rosenberg.md
@@ -1,26 +1,23 @@
 ---
 title: Paul Rosenberg
-author: Paul Rosenberg
-authorurl: http://www.weusecoins.com/paul-rosenberg/
 seotitle: Paul Rosenberg - CEO of Cryptohippie USA
-img: 
-name: Paul Rosenberg
+img:
 position: CEO, Cryptohippie USA
-education: 
-experience: 
+education:
+experience:
 short_desc: Paul Rosenberg is the CEO of Cryptohippie USA.
-long_desc: 
+long_desc:
 affiliations: [Cryptohippie]
-twitter: 
-github: 
-residence: 
+twitter:
+github:
+residence:
 cats: [ ]
-website: 
+website:
 ---
-Paul Rosenberg is a founder of [Cryptohippie](https://secure.cryptohippie.com/weusecoins.php), and CEO of Cryptohippie USA, the sales branch of the Cryptohippie suite of companies. 
+Paul Rosenberg is a founder of [Cryptohippie](https://secure.cryptohippie.com/weusecoins.php), and CEO of Cryptohippie USA, the sales branch of the Cryptohippie suite of companies.
 
-Paul is also the author of the [Free-Man's Perspective](http://freemansperspective.com) monthly newsletter and a lifestyle capitalist with a broad range of interests and experience. This diverse interest base is reflected in his extensive repertoire of published titles, including _A Lodging of Wayfaring Men_, _The Words of the Founders_, and _Production Versus Plunder_, not to mention 55 engineering and construction books. 
+Paul is also the author of the [Free-Man's Perspective](http://freemansperspective.com) monthly newsletter and a lifestyle capitalist with a broad range of interests and experience. This diverse interest base is reflected in his extensive repertoire of published titles, including _A Lodging of Wayfaring Men_, _The Words of the Founders_, and _Production Versus Plunder_, not to mention 55 engineering and construction books.
 
-Previous to his current activities, he developed a successful engineering career that saw him called as an expert witness in numerous legal cases and consulting a number of high profile organizations. Paul developed and taught nineteen continuing ed. courses for Iowa State University's College of Engineering and co-founded the Fiber Optic Association. 
+Previous to his current activities, he developed a successful engineering career that saw him called as an expert witness in numerous legal cases and consulting a number of high profile organizations. Paul developed and taught nineteen continuing ed. courses for Iowa State University's College of Engineering and co-founded the Fiber Optic Association.
 
 Cryptohippie has offered all We Use Coins readers a [free trial](https://secure.cryptohippie.com/weusecoins.php) of their privacy service.

--- a/_people/peter-gray.md
+++ b/_people/peter-gray.md
@@ -1,22 +1,17 @@
 ---
 title: Peter D. Gray
-author: Peter D. Gray
-authorurl: https://www.weusecoins.com/peter-gray/
-published: true
 seotitle: Peter D. Gray - CTO & Co-founder, Coinkite
 img: /images/peter-gray.png
-name: Peter D. Gray
 position: CTO & Co-founder, Coinkite
-education: 
-experience: 
-short_desc: Peter D. Gray is the CTO & Co-founder of Coinkite. 
-long_desc: 
+education:
+experience:
+short_desc: Peter D. Gray is the CTO & Co-founder of Coinkite.
+long_desc:
 affiliations: [Coinkite]
 twitter: dochex
-github: 
-residence: 
+github:
+residence:
 cats: [ ]
-website: 
+website:
 ---
 Peter has been programmer since before there was a web. He eats, lives and sleeps code; but he's also a fan of good UX, design and typography. A rare crossbreed of business person and technology master, he's founded a number of companies and still loves the role of an active CTO who still codes everyday.
-

--- a/_people/peter-kirby.md
+++ b/_people/peter-kirby.md
@@ -1,24 +1,20 @@
 ---
 title: Peter Kirby
-author: Nicola Minichiello
-authorurl: https://www.weusecoins.com/nicola-minichiello
-published: true
 seotitle: Peter Kirby
 img: /images/peter-kirby.png
-name: Peter Kirby
 position: CEO, Factom
 education: Degree in Biochemistry from Lehigh University, MBA in Entrepreneurship from Acton School of Business
-experience: 
-short_desc: Peter Kirby is the CEO of Factom. 
-long_desc: 
+experience:
+short_desc: Peter Kirby is the CEO of Factom.
+long_desc:
 affiliations: [Factom]
 twitter: petermkirby
-github: 
-residence: 
+github:
+residence:
 cats: [ ]
-website: 
+website:
 ---
-Peter Kirby is a seasoned executive with over twenty years of sales experience in the computer software, pharmaceuticals and real estate investment. Peter has a degree in Biochemistry from Lehigh University, and an MBA in Entrepreneurship from Acton School of Business. He works with leaders in financial services, government and law to address the most complex data security issues around the globe. 
+Peter Kirby is a seasoned executive with over twenty years of sales experience in the computer software, pharmaceuticals and real estate investment. Peter has a degree in Biochemistry from Lehigh University, and an MBA in Entrepreneurship from Acton School of Business. He works with leaders in financial services, government and law to address the most complex data security issues around the globe.
 
 Peter has spent the past 15 years involved in numerous successful early-stage tech companies, and possesses a deep knowledge of business development and community-based marketing in the technology sector. As a leader in the blockchain space, Peter has led multi-million dollar operations and was the driving force behind delivering major products to market. Peter’s expertise has made him a sought-after speaker across the world, as well as a trusted source to leading outlets such as The Wall Street Journal, Financial Times and numerous other industry trade publications.
 

--- a/_people/peter-todd.md
+++ b/_people/peter-todd.md
@@ -1,21 +1,20 @@
 ---
 title: Peter Todd
-seotitle: 
+seotitle:
 img: /images/peter-todd.png
-name: Peter Todd
 position: Bitcoin Core Developer
-education: 
-experience: 
-short_desc: 
-long_desc: 
+education:
+experience:
+short_desc:
+long_desc:
 affiliations: [Bitcoin Core]
 twitter: petertoddbtc
 github: petertodd
-residence: 
+residence:
 cats: [ ]
 website: https://petertodd.org/  
 ---
-Peter Todd is a Bitcoin Core developer, and an advisor to [Coinkite](/coinkite/). 
+Peter Todd is a Bitcoin Core developer, and an advisor to [Coinkite](/coinkite/).
 
 ## Bitcoin Core
 
@@ -27,12 +26,12 @@ Todd submitted his first bit of code to Bitcoin Core in April 2012, and today is
 
 [BIP 65](https://github.com/bitcoin/bips/blob/master/bip-0065.mediawiki) added "a new opcode (OP_CHECKLOCKTIMEVERIFY) for the Bitcoin scripting system that allows a transaction output to be made unspendable until some point in the future."
 
-In simpler terms, OP_CHECKLOCKTIMEVERIFY allows you to send money that cannot be spent until a specified future date. 
+In simpler terms, OP_CHECKLOCKTIMEVERIFY allows you to send money that cannot be spent until a specified future date.
 
 ### Opt-in Full Replace-by-Fee Signaling (BIP 125)
 
-[BIP 125](https://github.com/bitcoin/bips/blob/master/bip-0125.mediawiki) explained opt-in full-RBF. Transaction fees are rising and opt-in full-RBF allows senders with stuck transactions to send a new transaction with a higher fee. Opt-in RBF was merged in Bitcoin Core [version 0.12](https://bitcoin.org/en/release/v0.12.0). 
+[BIP 125](https://github.com/bitcoin/bips/blob/master/bip-0125.mediawiki) explained opt-in full-RBF. Transaction fees are rising and opt-in full-RBF allows senders with stuck transactions to send a new transaction with a higher fee. Opt-in RBF was merged in Bitcoin Core [version 0.12](https://bitcoin.org/en/release/v0.12.0).
 
 ### BIP 63
 
-A BIP by Todd titled "Stealth Addresses" has been assigned BIP #63 but has yet to be published. 
+A BIP by Todd titled "Stealth Addresses" has been assigned BIP #63 but has yet to be published.

--- a/_people/pieter-wuille.md
+++ b/_people/pieter-wuille.md
@@ -1,12 +1,11 @@
 ---
 title: Pieter Wuille
 img: /images/people/pieter-wuille.jpg
-name: Pieter Wuille
 position: Bitcoin Core Developer
 education: Ph.D. in Computer Science from University of Leuven
-experience: 
+experience:
 short_desc: Peter Wuille is a Bitcoin Core developer and the co-founder of Blockstream.
-long_desc: 
+long_desc:
 affiliations: [Bitcoin Core, Blockstream]
 twitter: pwuille
 github: sipa
@@ -14,36 +13,31 @@ residence: Switzerland
 website: http://bitcoin.sipa.be/
 seotitle: Pieter Wuille - Bitcoin Core Developer
 ---
-Peter Wuille is a [Bitcoin Core](/bitcoin-core/) developer and the co-founder of Blockstream. He is #2 in terms of commits to Bitcoin Core and is responsible for important improvements to Bitcoin like [BIP 66](https://github.com/bitcoin/bips/blob/master/bip-0066.mediawiki), [libsecp256k1](https://github.com/bitcoin/secp256k1), and [Segregated Witness](https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki). 
+Peter Wuille is a [Bitcoin Core](/bitcoin-core/) developer and the co-founder of Blockstream. He is #2 in terms of commits to Bitcoin Core and is responsible for important improvements to Bitcoin like [BIP 66](https://github.com/bitcoin/bips/blob/master/bip-0066.mediawiki), [libsecp256k1](https://github.com/bitcoin/secp256k1), and [Segregated Witness](https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki).
 
 ## Bitcoin Core
 
-Wuille discovered Bitcoin in 2010 and has been a Bitcoin Core developer since May 2011. In 2012, Wuille published [BIP 32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki), which added  hierarchical deterministic wallets to Bitcoin. 
+Wuille discovered Bitcoin in 2010 and has been a Bitcoin Core developer since May 2011. In 2012, Wuille published [BIP 32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki), which added  hierarchical deterministic wallets to Bitcoin.
 
-Segregated Witness is Wuille's latest contribution, and is currently live on testnet. Full network activation is expected in April 2016. 
+Segregated Witness is Wuille's latest contribution, and is currently live on testnet. Full network activation is expected in April 2016.
 
 ## Blockstream
 
-Blockstream builds open source software and infrastructure for Bitcoin, including the lightning network and sidechains. Wuille co-founded the company in 2014 and currently serves as a core-tech engineer. Blockstream has raised [over $65 million in venture capital](/en/venture-capital-investments-in-bitcoin-and-blockchain-companies/). 
+Blockstream builds open source software and infrastructure for Bitcoin, including the lightning network and sidechains. Wuille co-founded the company in 2014 and currently serves as a core-tech engineer. Blockstream has raised [over $65 million in venture capital](/en/venture-capital-investments-in-bitcoin-and-blockchain-companies/).
 
 ## Segregated Witness
 
-Wuille's [Segregated Witness](https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki) was introduced at Scaling Bitcoin Hong Kong 2015. SegWit improves the Bitcoin protocol by decreasing the amount of data used by each transaction, which effectively increases transaction capacity without the need for a hard fork. 
+Wuille's [Segregated Witness](https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki) was introduced at Scaling Bitcoin Hong Kong 2015. SegWit improves the Bitcoin protocol by decreasing the amount of data used by each transaction, which effectively increases transaction capacity without the need for a hard fork.
 
 Early Bitcoin investor [Trace Mayer](/trace-mayer-bitcoin-expert/) called SegWit "a tremendous innovation".
 
 ## Videos
 
-A presentation on Segregated Witness. 
+A presentation on Segregated Witness.
 
 <iframe width="640" height="360" src="https://www.youtube.com/embed/NOYNZB5BCHM" frameborder="0" allowfullscreen></iframe>
 
 ## More Bitcoin Core Developers
 
-<div class="similar-people-wrap">
-{% for person in site.people %}
-{% if person.affiliations contains 'Bitcoin Core' and page.name != person.name %}
-{% include similar-people.html %}
-{% endif %}
-{% endfor %}
-</div>
+{% assign organization = page.affiliations[0] %}
+{% include similar-people.html organization=organization name=page.title %}

--- a/_people/reggie-middleton.md
+++ b/_people/reggie-middleton.md
@@ -2,16 +2,15 @@
 title: Reggie Middleton
 img: /images/reggie-middleton.png
 seotitle: Reggie Middleton - Ultra-coin
-name: Reggie Middleton
 position: Ultra-coin
 education: Bachelor's Degree in Business Management
-experience: 
-short_desc: 
-long_desc: 
+experience:
+short_desc:
+long_desc:
 affiliations: [Ultra-coin]
 twitter: reggiemiddleton
-github: 
-residence: 
+github:
+residence:
 cats: [ ]
 website: http://veritaseum.com
 ---

--- a/_people/rodolfo-novak.md
+++ b/_people/rodolfo-novak.md
@@ -1,20 +1,16 @@
 ---
 title: Rodolfo Novak
-author: Rodolfo Novak
-authorurl: https://www.weusecoins.com/rodolfo-novak/
-published: true
 seotitle: Rodolfo Novak - CEO & Co-founder, Coinkite
 img: /images/rodolfo-novak.png
-name: Rodolfo Novak
 position: CEO & Co-founder, Coinkite
-education: 
-experience: 
-short_desc: Rodolfo Novak is the CEO & Co-founder of Coinkite. 
-long_desc: 
+education:
+experience:
+short_desc: Rodolfo Novak is the CEO & Co-founder of Coinkite.
+long_desc:
 affiliations: [Coinkite]
 twitter: nvk
 github: nvk
-residence: 
+residence:
 cats: [ ]
 website: http://rnvk.org/
 ---

--- a/_people/roy-sebag.md
+++ b/_people/roy-sebag.md
@@ -1,22 +1,18 @@
 ---
 title: Roy Sebag - CEO Bitgold
-author: Roy Sebag - CEO Bitgold
-authorurl: /roy-sebag/
-published: true
 seotitle: Roy Sebag - CEO Bitgold
 img: /images/roy-sebag.png
-name: Roy Sebag
 position: CEO, Bitgold
-education: 
-experience: 
+education:
+experience:
 short_desc: Roy Sebag is the founder and team leader of BitGold.
-long_desc: 
+long_desc:
 affiliations: [BitGold]
 twitter: roysebag
-github: 
-residence: 
+github:
+residence:
 cats: [ ]
-website: 
+website:
 ---
 Roy Sebag is the founder and team leader of <a href="/bitgold/">BitGold</a>.
 
@@ -28,10 +24,5 @@ Roy loves to consume information and is a voracious reader of all things science
 
 ## BitGold Executive Management Team Members
 
-<div class="similar-people-wrap">
-{% for person in site.people %}
-{% if person.affiliations contains 'BitGold' and page.name != person.name %}
-{% include similar-people.html %}
-{% endif %}
-{% endfor %}
-</div>
+{% assign organization = page.affiliations[0] %}
+{% include similar-people.html organization=organization name=page.title %}

--- a/_people/sam-patterson.md
+++ b/_people/sam-patterson.md
@@ -2,22 +2,21 @@
 title: Sam Patterson
 seotitle: Sam Patterson - COO, OB1
 img: /images/sam-patterson.jpg
-name: Sam Patterson
 position: COO, OB1
-education: 
-experience: 
+education:
+experience:
 short_desc: Sam Patterson is the Operations Lead of OpenBazaar, and the COO of OB1.
-long_desc: 
+long_desc:
 affiliations: [OB1, OpenBazaar]
 twitter: samuelpatt
 github: SamPatt
-residence: 
+residence:
 cats: [ ]
-website: 
+website:
 ---
 Sam Patterson is the Operations Lead of [OpenBazaar](/openbazaar/), and the COO of OB1. Patterson co-founded OpenBazaar [to](https://www.linkedin.com/in/sam-patterson-0943901b) "help bring decentralized trade to the world".
 
-Previously, he worked at the Charles Koch Institute as a Senior Policy Analyst and Research Fellow. 
+Previously, he worked at the Charles Koch Institute as a Senior Policy Analyst and Research Fellow.
 
 ## Links
 
@@ -26,13 +25,8 @@ Previously, he worked at the Charles Koch Institute as a Senior Policy Analyst a
 
 ## More OpenBazaar Developers
 
-<div class="similar-people-wrap">
-{% for person in site.people %}
-{% if person.affiliations contains 'OpenBazaar' and page.name != person.name %}
-{% include similar-people.html %}
-{% endif %}
-{% endfor %}
-</div>
+{% assign organization = page.affiliations[1] %}
+{% include similar-people.html organization=organization name=page.title %}
 
 ## Video
 

--- a/_people/tony-gallippi.md
+++ b/_people/tony-gallippi.md
@@ -1,21 +1,17 @@
 ---
 title: Tony Gallippi
-author: Tony Gallippi
-authorurl: https://www.weusecoins.com/tony-gallippi/
-published: true
 seotitle: Tony Gallippi - Co-founder, BitPay
 img: /images/tony-gallippi.png
-name: Tony Gallippi
 position: Co-founder, BitPay
 education: Bachelor's degree in Mechanical Engineering from Georgia Tech
-experience: 
+experience:
 short_desc: Tony Gallippi is the co-founder and executive chairman of Bitpay.
-long_desc: 
+long_desc:
 affiliations: [BitPay]
 twitter: tonygallippi
-github: 
-residence: 
+github:
+residence:
 cats: [ ]
-website: 
+website:
 ---
 Tony Gallippi is the co-founder and executive chairman of BitPay. Tony has 20 years of experience in Sales and Marketing in the Robotics and Financial industries. Tony has a Bachelor's degree in Mechanical Engineering from Georgia Tech.

--- a/_people/trace-mayer-bitcoin-expert.md
+++ b/_people/trace-mayer-bitcoin-expert.md
@@ -1,20 +1,16 @@
 ---
 title: Trace Mayer - Bitcoin Expert
-author: Trace Mayer, J.D.
-authorurl: https://www.tracemayer.net
-published: true
 img: /images/trace-mayer.png
 seotitle: Trace Mayer - Bitcoin Expert
-name: Trace Mayer
 position: Bitcoin Expert
 education: Degrees in Accounting and Law
-experience: 
+experience:
 short_desc: An entrepreneur, investor, journalist, monetary scientist and ardent defender of the freedom of speech.
-long_desc: 
+long_desc:
 affiliations: [BitPay, Armory, Kraken, Bitcoin Knowledge]
 twitter: tracemayer
 github: sunnankar
-residence: 
+residence:
 cats: featured
 website: https://tracemayer.net
 ---
@@ -29,7 +25,7 @@ He was among the first popular bloggers to publicly recommend Bitcoin in its inf
 
 <a href="http://www.bitcoinarmory.com" align="left" target="_blank"><img
  src="http://www.tracemayer.net/images/armory.png" alt="Armory"
- style="border: 0px solid ; width: 200px; height: 58px;"></a> 
+ style="border: 0px solid ; width: 200px; height: 58px;"></a>
  <a href="http://www.bitpay.com" align="middle" target="_blank"><img
  src="http://www.tracemayer.net/images/bitpay.png" alt="Bitpay"
  style="border: 0px solid ; width: 200px; height: 58px;"></a> <a href="http://www.bitcoinmagazine.com" align="right" target="_blank"><img
@@ -39,12 +35,12 @@ He was among the first popular bloggers to publicly recommend Bitcoin in its inf
  <a href="http://www.kraken.com" align="left" target="_blank"><img
  src="http://www.tracemayer.net/images/kraken.png" alt="Kraken"
  style="border: 0px solid ; width: 200px; height: 58px;"></a>
- 
+
 ## Bitcoin articles by Trace Mayer
 
 <ul>
 <li><a href="/crypsa-future-of-bitcoin/">CRYPSA Event - The Future of Bitcoin</a></li>
-</ul> 
+</ul>
 
 ##### Speaker Intro Video
 

--- a/_people/vitalik-buterin.md
+++ b/_people/vitalik-buterin.md
@@ -1,20 +1,16 @@
 ---
 title: Vitalik Buterin
-author: Vitalik Buterin
-authorurl: /vitalik-buterin/
-published: true
 seotitle: Vitalik Buterin - Founder, Ethereum
 img: /images/vitalik-buterin.png
-name: Vitalik Buterin
 position: Founder, Ethereum
-education: 
-experience: 
+education:
+experience:
 short_desc: Vitalik Buterin is the Founder of Ethereum.
-long_desc: 
+long_desc:
 affiliations: [Ethereum]
 twitter: vitalikbuterin
-github: 
-residence: 
+github:
+residence:
 cats: featured
 website: http://vitalik.ca
 ---

--- a/_people/washington-sanchez.md
+++ b/_people/washington-sanchez.md
@@ -2,24 +2,23 @@
 title: Washington Sanchez
 seotitle: Washington Sanchez - Co-founder, OB1
 img: /images/washington-sanchez.jpg
-name: Washington Sanchez
 position: Co-founder, OB1
-education: 
-experience: 
-short_desc: 
-long_desc: 
+education:
+experience:
+short_desc:
+long_desc:
 affiliations: [OB1, OpenBazaar]
 twitter: drwasho
 github: drwasho
-residence: 
+residence:
 cats: [ ]
-website: 
+website:
 ---
 Washington Sanchez is a Co-founder of OB1 and a core developer of [OpenBazaar](/openbazaar/).  
 
 ## Work on OpenBazaar
 
-Sanchez is responisble for implementing OpenBazaar's market protocol. He also [published OpenBazaar's proposal](https://gist.github.com/drwasho/a5380544c170bdbbbad8) for Ricardian Contracts. 
+Sanchez is responisble for implementing OpenBazaar's market protocol. He also [published OpenBazaar's proposal](https://gist.github.com/drwasho/a5380544c170bdbbbad8) for Ricardian Contracts.
 
 ## Links
 
@@ -27,10 +26,5 @@ How to stop a Bitcoin hard fork… or how to accelerate it - by [Washington Sanc
 
 ## More OpenBazaar Developers
 
-<div class="similar-people-wrap">
-{% for person in site.people %}
-{% if person.affiliations contains 'OpenBazaar' and page.name != person.name %}
-{% include similar-people.html %}
-{% endif %}
-{% endfor %}
-</div>
+{% assign organization = page.affiliations[1] %}
+{% include similar-people.html organization=organization name=page.title %}

--- a/_people/wayne-vaughan.md
+++ b/_people/wayne-vaughan.md
@@ -2,22 +2,21 @@
 title: Wayne Vaughan
 seotitle: Wayne Vaughan - CEO, Tierion
 img: /images/wayne-vaughan.png
-name: Wayne Vaughan
 position: CEO, Tierion
-education: 
-experience: 
-short_desc: Wayne Vaughan is the CEO of Tierion and the President of Fuscient. 
-long_desc: 
+education:
+experience:
+short_desc: Wayne Vaughan is the CEO of Tierion and the President of Fuscient.
+long_desc:
 affiliations: [Tierion, Fuscient]
 twitter: waynevaughan
-github: 
-residence: 
+github:
+residence:
 cats: [ ]
-website: 
+website:
 ---
-Wayne Vaughan is the CEO of [Tierion](https://tierion.com/), a cloud-based storage system that allows for trustless verification of data on the Bitcoin blockchain. 
+Wayne Vaughan is the CEO of [Tierion](https://tierion.com/), a cloud-based storage system that allows for trustless verification of data on the Bitcoin blockchain.
 
-He also serves as the President of Fuscient, a digital marketing agency. 
+He also serves as the President of Fuscient, a digital marketing agency.
 
 ## Links
 

--- a/_people/wladimir-van-der-laan.md
+++ b/_people/wladimir-van-der-laan.md
@@ -2,51 +2,45 @@
 title: Wladimir van der Laan
 seotitle: Wladimir van der Laan - Lead Maintainer, Bitcoin Core
 img: /images/van-der-laan.png
-name: Wladimir van der Laan
 position: Lead Maintainer, Bitcoin Core
-education: 
-experience: 
-short_desc: 
-long_desc: 
+education:
+experience:
+short_desc:
+long_desc:
 affiliations: [Bitcoin Core, MIT Digital Currency Initiative]
 twitter: orionwl
 github: laanwj
-residence: 
+residence:
 cats: [ ]
-website: 
+website:
 ---
 
-Wladimir van der Laan is a [Bitcoin Core](/bitcoin-core/) Developer and the Lead Maintainer of the Bitcoin repository on GitHub. 
+Wladimir van der Laan is a [Bitcoin Core](/bitcoin-core/) Developer and the Lead Maintainer of the Bitcoin repository on GitHub.
 
 ## Bitcoin Core
 
-From mid-2010 until April-2014, [Gavin Andresen](/gavin-andresen/) maintained control of the Bitcoin Core GitHub repository and was considered Bitcoin’s lead developer. On April 8, 2014, Andresen stepped down and van der Laan agreed to take over as Lead Maintainer of the Bitcoin repo. His salary is paid by MIT’s Digital Currency Initiative, where he works on Bitcoin development with Andresen and Cory Fields. 
+From mid-2010 until April-2014, [Gavin Andresen](/gavin-andresen/) maintained control of the Bitcoin Core GitHub repository and was considered Bitcoin’s lead developer. On April 8, 2014, Andresen stepped down and van der Laan agreed to take over as Lead Maintainer of the Bitcoin repo. His salary is paid by MIT’s Digital Currency Initiative, where he works on Bitcoin development with Andresen and Cory Fields.
 
 ## Scaling Debate
 
-van der Laan has taken more of a backseat approach in Bitcoin's scaling debate. [He stated](http://coinjournal.net/who-asked-wlad-what-does-bitcoins-lead-developer-say-about-scaling-debate-exclusive/) that there is "a problem with proposals that bake in expected exponential bandwidth growth" and that a "a hardfork is extremely hard to coordinate". 
+van der Laan has taken more of a backseat approach in Bitcoin's scaling debate. [He stated](http://coinjournal.net/who-asked-wlad-what-does-bitcoins-lead-developer-say-about-scaling-debate-exclusive/) that there is "a problem with proposals that bake in expected exponential bandwidth growth" and that a "a hardfork is extremely hard to coordinate".
 
 ## Controversey
 
-Because Bitcoin is a decentralized system, van der Laan believes that any code changes or BIP proposals must reach consensus among other Core developers before being implemented. Former Bitcoin developer Mike Hearn is one of the critics who have claimed that van der Laan's approach is too conservative. 
+Because Bitcoin is a decentralized system, van der Laan believes that any code changes or BIP proposals must reach consensus among other Core developers before being implemented. Former Bitcoin developer Mike Hearn is one of the critics who have claimed that van der Laan's approach is too conservative.
 
 ## Quotes
 
-On [Bitcoin scaling proposals](http://coinjournal.net/who-asked-wlad-what-does-bitcoins-lead-developer-say-about-scaling-debate-exclusive/): 
+On [Bitcoin scaling proposals](http://coinjournal.net/who-asked-wlad-what-does-bitcoins-lead-developer-say-about-scaling-debate-exclusive/):
 
 > I mostly have a problem with proposals that bake in expected exponential bandwidth growth. I don’t think it’s realistic. If we’ve learned anything from the 2008 subprime bubble crisis it should be that nothing ever keeps growing exponentially, and assuming so can be hazardous.
 It reduces a complex geographical issue, the distribution of internet connectivity over the planet for a long time to come, to a simple function.
 
-On [hardforks](http://coinjournal.net/who-asked-wlad-what-does-bitcoins-lead-developer-say-about-scaling-debate-exclusive/): 
+On [hardforks](http://coinjournal.net/who-asked-wlad-what-does-bitcoins-lead-developer-say-about-scaling-debate-exclusive/):
 
 > On the other hand a hardfork is extremely hard to coordinate. Even one that just involves changing one parameter. Everyone with a full node has to upgrade. This is not something that can be done regularly. Certainly not with such a near time horizon. Changing the rules in a decentralized consensus system is a very difficult problem and I don’t think we’ll resolve it any time soon.
 
 ## More Bitcoin Core Developers
 
-<div class="similar-people-wrap">
-{% for person in site.people %}
-{% if person.affiliations contains 'Bitcoin Core' and page.name != person.name %}
-{% include similar-people.html %}
-{% endif %}
-{% endfor %}
-</div>
+{% assign organization = page.affiliations[0] %}
+{% include similar-people.html organization=organization name=page.title %}

--- a/_people/zooko-wilcox-ohearn.md
+++ b/_people/zooko-wilcox-ohearn.md
@@ -1,22 +1,18 @@
 ---
 title: Zooko Wilcox
-author: Zooko Wilcox
-authorurl: https://www.weusecoins.com/zooko-wilcox-ohearn/
-published: true
 seotitle: Zooko Wilcox - Founder & CEO, Zcash
 img: /images/zooko-wilcox.jpg
-name: Zooko Wilcox
 position: Founder & CEO, Zcash
-education: 
-experience: 
-short_desc: Zooko Wilcox is the Founder & CEO of Zcash. 
-long_desc: 
+education:
+experience:
+short_desc: Zooko Wilcox is the Founder & CEO of Zcash.
+long_desc:
 affiliations: [Zcash]
 twitter: zooko
-github: 
-residence: 
+github:
+residence:
 cats: [ ]
-website: 
+website:
 ---
 
 Zooko Wilcox is CEO of Least Authority and covers areas including engineering, security, operations and customer support.

--- a/_sass/_components.scss
+++ b/_sass/_components.scss
@@ -2,3 +2,4 @@
 @import 'components/social-shares';
 @import 'components/hardware';
 @import 'components/tables';
+@import 'components/people';

--- a/_sass/components/_people.scss
+++ b/_sass/components/_people.scss
@@ -1,0 +1,57 @@
+.person-list {
+    width: 100%;
+    text-align: center;
+}
+
+.person-display {
+  display: inline-block;
+  margin: 15px 10px 35px;
+  min-width: 150px;
+  text-align: center;
+
+	img {
+		border-radius: 50%;
+		width: 65px;
+		height: auto;
+	}
+
+	.name {
+		font-size: 15px;
+	}
+
+	.position {
+		color: #989898;
+		font-size: 14px;
+	}
+}
+
+.person-info {
+  background: #f9f9f9 none repeat scroll 0 0;
+  border: 1px solid #aaa;
+  float: right;
+  font-size: 14px;
+  padding: 15px 15px 0;
+  width: 250px;
+  margin: 0 0 10px 15px;
+
+	.person-img-wrap {
+		text-align: center;
+	}
+
+	img {
+		border-radius: 50%;
+		max-width: 220px;
+	}
+
+	span {
+		font-weight: bold;
+	}
+
+	p {
+		clear: both;
+	}
+
+	@include mobile {
+		width: 100%;
+	}
+}

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -467,65 +467,8 @@ iframe {
   max-width: 100%;
 }
 
-.similar-people {
-	
-	display: inline-block;
-    margin: 15px 10px 35px;
-    min-width: 150px;
-    text-align: center;
-	
-	
-	img {
-		border-radius: 50%;
-		width: 65px;
-		height: auto;
-	}
-	
-	.name {
-		font-size: 15px;
-	}
-	
-	.position {
-		color: #989898;
-		font-size: 14px;
-	}
-}
-
-.similar-people-wrap {
-    float: left;
-    width: 100%;
-    text-align: center;
-}
-
 hr {
 	clear: both;
-}
-
-.person-info {
-	background: #f9f9f9 none repeat scroll 0 0;
-    border: 1px solid #aaa;
-    float: right;
-    font-size: 14px;
-    padding: 15px 15px 0;
-    width: 250px;
-    margin: 0 0 10px 15px;
-	
-	.person-img-wrap {
-		text-align: center;
-	}
-	img {
-		border-radius: 50%;
-		max-width: 220px;
-	}
-	span {
-		font-weight: bold;
-	}
-	p {
-		clear: both;
-	}
-	@include mobile {
-		width: 100%;
-	}
 }
 
 // Banner on index "Why Bitcoin"
@@ -691,16 +634,16 @@ a.anchor {
 }
 
 .company-wrap {
-	
+
 	width: 100%;
 	text-align: center;
-	
+
 	h3 {
 	    display: inline-block;
 	    margin: 20px 10px;
 	    width: 120px;
 	}
-	
+
 	img {
 		width: 65px;
 		border-radius: 3px;

--- a/en/whos-who/index.html
+++ b/en/whos-who/index.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Learn from the top people in the Bitcoin world
-toc: 
+toc:
   back: Dr. Adam Back
   companies: Companies
   ind: Individuals
@@ -32,73 +32,37 @@ toc:
 
 <p><a href="/bitcoin-core/">Bitcoin Core</a>--formerly Bitcoin-Qt--is a Bitcoin codebase based on the original code and framework published by Satoshi Nakamoto. Bitcoin Core is currently run by more than 70% of Bitcoin nodes and all miners, making it the most widely used Bitcoin client. Note that Bitcoin Core is not a company.</p>
 
-<div class="similar-people-wrap">
-{% for person in site.people %}
-{% if person.affiliations contains 'Bitcoin Core' %}
-{% include similar-people.html %}
-{% endif %}
-{% endfor %}
-</div>
+{% include similar-people.html organization="Bitcoin Core" %}
 
 <h3>Blockstream</h3>
 
 <p><a href="/blockstream/">Blockstream</a> is one of the most-well funded Bitcoin companies, with $76 million in venture capital thanks to its latest $55 million funding round. Its core purpose is to improve Bitcoin's utility with sidechains.</p>
 
-<div class="similar-people-wrap">
-{% for person in site.people %}
-{% if person.affiliations contains 'Blockstream' %}
-{% include similar-people.html %}
-{% endif %}
-{% endfor %}
-</div>
+{% include similar-people.html organization="Blockstream" %}
 
 <h3>Armory</h3>
 
 <p><a href="/armory/">Armory</a> builds enterprise grade Bitcoin security software solutions and provides Bitcoin security consulting services to institutions for deploying a Bitcoin security plan.</p>
 
-<div class="similar-people-wrap">
-{% for person in site.people %}
-{% if person.affiliations contains 'Armory' %}
-{% include similar-people.html %}
-{% endif %}
-{% endfor %}
-</div>
+{% include similar-people.html organization="Armory" %}
 
 <h3>Coinbase</h3>
 
 <p><a href="/coinbase-review/">Coinbase</a> aims to be the easiest way to get started with Bitcoin. Users can easily buy & sell bitcoins, or accept bitcoin as a merchant. </p>
 
-<div class="similar-people-wrap">
-{% for person in site.people %}
-{% if person.affiliations contains 'Coinbase' %}
-{% include similar-people.html %}
-{% endif %}
-{% endfor %}
-</div>
+{% include similar-people.html organization="Coinbase" %}
 
 <h3>Ledger</h3>
 
 <p><a href="/ledger/">Ledger</a> is a Bitcoin security company known for its Bitcoin hardware wallets.</p>
 
-<div class="similar-people-wrap">
-{% for person in site.people %}
-{% if person.affiliations contains 'Ledger' %}
-{% include similar-people.html %}
-{% endif %}
-{% endfor %}
-</div>
+{% include similar-people.html organization="Ledger" %}
 
 <h3>OpenBazaar</h3>
 
 <p><a href="/openbazaar/">OpenBazaar</a> is a Bitcoin-only, decentralized online marketplace. It is currently developed by OB1.</p>
 
-<div class="similar-people-wrap">
-{% for person in site.people %}
-{% if person.affiliations contains 'OpenBazaar' %}
-{% include similar-people.html %}
-{% endif %}
-{% endfor %}
-</div>
+{% include similar-people.html organization="OpenBazaar" %}
 
 <h3>More Bitcoin Companies</h3>
 
@@ -118,11 +82,11 @@ You don't need to work for a company to contribute in the Bitcoin space. Meet mo
 
 <h3></h3>
 
-<div class="similar-people-wrap">
+<div class="person-list">
 {% for person in site.people %}
-{% if person.cats contains 'featured' %}
-{% include similar-people.html %}
-{% endif %}
+  {% if person.cats contains 'featured' %}
+    {% include person.html %}
+  {% endif %}
 {% endfor %}
 </div>
 


### PR DESCRIPTION
I went through all the company and people files and cleaned up the loops, essentially making the include more versatile. It is important to note that the "title" variable has to be the exact name of the company or person, otherwise it won't get recognized by our loops, we have the seotitle variable for a more descriptive title.

Also, pages (i.e. companies and profiles) do not utilize the author, authorurl variables, so these are obsolete there.