### PR TITLE
Adding Bitwage To WeUseCoins

### DIFF
--- a/_data/buy.yml
+++ b/_data/buy.yml
@@ -6,6 +6,12 @@
    logo: coinbase-small.png
    url: http://geni.us/coinbase
    
+ - payroll & invoicing: Bitwage
+   description: <p>Bitwage is the most popular bitcoin payroll & invoicing solution.  Bitwage has users in over 70 differen countries.  Bitwage allows users to receive wages and invoice payments from any US, EU or UK company in Bitcoin.  Bitwage provides users with local bank accounts in US, EU and UK to receive wages in fiat currency, converts those funds into Bitcoin and sends those Bitcoin to whatever wallet a worker wishes to receive their wages into.  This works with wage payments and business dispursements from any company with requiring the company to sign up.  Bitwage users can split between Bitcoin and local currency.
+   countries: AF,AX,AL,DZ,AS,AD,AO,AI,AQ,AG,AR,AM,AW,AU,AT,AZ,BS,BH,BD,BB,BY,BE,BZ,BJ,BM,BT,BO,BQ,BA,BW,BV,BR,IO,BN,BG,BF,BI,KH,CM,CA,CV,KY,CF,TD,CL,CN,CX,CC,CO,KM,CG,CD,CK,CR,CI,HR,CU,CW,CY,CZ,DK,DJ,DM,DO,EC,EG,SV,GQ,ER,EE,ET,FK,FO,FJ,FI,FR,GF,PF,TF,GA,GM,GE,DE,GH,GI,GR,GL,GD,GP,GU,GT,GG,GN,GW,GY,HT,HM,VA,HN,HK,HU,IS,IN,ID,IQ,IE,IM,IL,IT,JM,JP,JE,JO,KZ,KE,KI,KR,KW,KG,LA,LV,LB,LS,LR,LY,LI,LT,LU,MO,MK,MG,MW,MY,MV,ML,MT,MH,MQ,MR,MU,YT,MX,FM,MD,MC,MN,ME,MS,MA,MZ,MM,NA,NR,NP,NL,NC,NZ,NI,NE,NG,NU,NF,MP,NO,OM,PK,PW,PS,PA,PG,PY,PE,PH,PN,PL,PT,PR,QA,RE,RO,RU,RW,BL,SH,KN,LC,MF,PM,VC,WS,SM,ST,SA,SN,RS,SC,SL,SG,SX,SK,SI,SB,SO,ZA,GS,SS,ES,LK,SD,SR,SJ,SZ,SE,CH,SY,TW,TJ,TZ,TH,TL,TG,TK,TO,TT,TN,TR,TM,TC,TV,UG,UA,AE,GB,US,UM,UY,UZ,VU,VE,VN,VG,VI,WF,EH,YE,ZM,ZW
+   logo: https://storage.googleapis.com/bitwage-prod-img/Bitwage_LogoSuite_Official.png?v=400026947054681105
+   url: https://www.bitwage.com
+   
  - exchange: Coinhouse
    description: Buy bitcoins in the UK and Europe with a 3D secure credit or debit card. Prepaid credit and debit cards are also accepted if 3D secure. 
    countries: ad, at, be, bg, hr, cy, cz, dk, ee, fi, fr, de, gr, hu, is, ie, it, lv, li, lt, lu, mt, mc, nl, nor, pl, pt, ro, sm, sk, si, es, se, ch, gb  
@@ -68,6 +74,12 @@
    logo: bitcoinde.png
    url: https://www.bitcoin.de/
    
+ - payroll & invoicing: Bitwage
+   description: <p>Bitwage is the most popular bitcoin payroll & invoicing solution.  Bitwage has users in over 70 differen countries.  Bitwage allows users to receive wages and invoice payments from any US, EU or UK company in Bitcoin.  Bitwage provides users with local bank accounts in US, EU and UK to receive wages in fiat currency, converts those funds into Bitcoin and sends those Bitcoin to whatever wallet a worker wishes to receive their wages into.  This works with wage payments and business dispursements from any company with requiring the company to sign up.  Bitwage users can split between Bitcoin and local currency.
+   countries: AF,AX,AL,DZ,AS,AD,AO,AI,AQ,AG,AR,AM,AW,AU,AT,AZ,BS,BH,BD,BB,BY,BE,BZ,BJ,BM,BT,BO,BQ,BA,BW,BV,BR,IO,BN,BG,BF,BI,KH,CM,CA,CV,KY,CF,TD,CL,CN,CX,CC,CO,KM,CG,CD,CK,CR,CI,HR,CU,CW,CY,CZ,DK,DJ,DM,DO,EC,EG,SV,GQ,ER,EE,ET,FK,FO,FJ,FI,FR,GF,PF,TF,GA,GM,GE,DE,GH,GI,GR,GL,GD,GP,GU,GT,GG,GN,GW,GY,HT,HM,VA,HN,HK,HU,IS,IN,ID,IQ,IE,IM,IL,IT,JM,JP,JE,JO,KZ,KE,KI,KR,KW,KG,LA,LV,LB,LS,LR,LY,LI,LT,LU,MO,MK,MG,MW,MY,MV,ML,MT,MH,MQ,MR,MU,YT,MX,FM,MD,MC,MN,ME,MS,MA,MZ,MM,NA,NR,NP,NL,NC,NZ,NI,NE,NG,NU,NF,MP,NO,OM,PK,PW,PS,PA,PG,PY,PE,PH,PN,PL,PT,PR,QA,RE,RO,RU,RW,BL,SH,KN,LC,MF,PM,VC,WS,SM,ST,SA,SN,RS,SC,SL,SG,SX,SK,SI,SB,SO,ZA,GS,SS,ES,LK,SD,SR,SJ,SZ,SE,CH,SY,TW,TJ,TZ,TH,TL,TG,TK,TO,TT,TN,TR,TM,TC,TV,UG,UA,AE,GB,US,UM,UY,UZ,VU,VE,VN,VG,VI,WF,EH,YE,ZM,ZW
+   logo: https://storage.googleapis.com/bitwage-prod-img/Bitwage_LogoSuite_Official.png?v=400026947054681105
+   url: https://www.bitwage.com
+   
  - exchange: SpectroCoin
    description: <p>SpectroCoin is an all-in-one solution for Bitcoin. Services offered include a wide range of Bitcoin solutions, from exchange to Bitcoin e-wallet.</p>
    countries: ca, ad, at, be, bg, hr, cy, cz, dk, ee, fi, fr, de, gr, hu, is, ie, it, lv, li, lt, lu, mt, mc, nl, nor, pl, pt, ro, sm, sk, si, es, se, ch, gb, sg, uk
@@ -105,6 +117,12 @@
    countries: uk
    logo: bittylicious.png
    url: https://bittylicious.com/
+   
+ - payroll & invoicing: Bitwage
+   description: <p>Bitwage is the most popular bitcoin payroll & invoicing solution.  Bitwage has users in over 70 differen countries.  Bitwage allows users to receive wages and invoice payments from any US, EU or UK company in Bitcoin.  Bitwage provides users with local bank accounts in US, EU and UK to receive wages in fiat currency, converts those funds into Bitcoin and sends those Bitcoin to whatever wallet a worker wishes to receive their wages into.  This works with wage payments and business dispursements from any company with requiring the company to sign up.  Bitwage users can split between Bitcoin and local currency.
+   countries: AF,AX,AL,DZ,AS,AD,AO,AI,AQ,AG,AR,AM,AW,AU,AT,AZ,BS,BH,BD,BB,BY,BE,BZ,BJ,BM,BT,BO,BQ,BA,BW,BV,BR,IO,BN,BG,BF,BI,KH,CM,CA,CV,KY,CF,TD,CL,CN,CX,CC,CO,KM,CG,CD,CK,CR,CI,HR,CU,CW,CY,CZ,DK,DJ,DM,DO,EC,EG,SV,GQ,ER,EE,ET,FK,FO,FJ,FI,FR,GF,PF,TF,GA,GM,GE,DE,GH,GI,GR,GL,GD,GP,GU,GT,GG,GN,GW,GY,HT,HM,VA,HN,HK,HU,IS,IN,ID,IQ,IE,IM,IL,IT,JM,JP,JE,JO,KZ,KE,KI,KR,KW,KG,LA,LV,LB,LS,LR,LY,LI,LT,LU,MO,MK,MG,MW,MY,MV,ML,MT,MH,MQ,MR,MU,YT,MX,FM,MD,MC,MN,ME,MS,MA,MZ,MM,NA,NR,NP,NL,NC,NZ,NI,NE,NG,NU,NF,MP,NO,OM,PK,PW,PS,PA,PG,PY,PE,PH,PN,PL,PT,PR,QA,RE,RO,RU,RW,BL,SH,KN,LC,MF,PM,VC,WS,SM,ST,SA,SN,RS,SC,SL,SG,SX,SK,SI,SB,SO,ZA,GS,SS,ES,LK,SD,SR,SJ,SZ,SE,CH,SY,TW,TJ,TZ,TH,TL,TG,TK,TO,TT,TN,TR,TM,TC,TV,UG,UA,AE,GB,US,UM,UY,UZ,VU,VE,VN,VG,VI,WF,EH,YE,ZM,ZW
+   logo: https://storage.googleapis.com/bitwage-prod-img/Bitwage_LogoSuite_Official.png?v=400026947054681105
+   url: https://www.bitwage.com
    
 ############## Canada ############## 
 
@@ -278,6 +296,12 @@
    countries: br
    logo: mercado.png
    url: https://www.mercadobitcoin.com.br/
+   
+ - payroll & invoicing: Bitwage
+   description: <p>Bitwage is the most popular bitcoin payroll & invoicing solution.  Bitwage has users in over 70 differen countries.  Bitwage allows users to receive wages and invoice payments from any US, EU or UK company in Bitcoin.  Bitwage provides users with local bank accounts in US, EU and UK to receive wages in fiat currency, converts those funds into Bitcoin and sends those Bitcoin to whatever wallet a worker wishes to receive their wages into.  This works with wage payments and business dispursements from any company with requiring the company to sign up.  Bitwage users can split between Bitcoin and local currency.
+   countries: AF,AX,AL,DZ,AS,AD,AO,AI,AQ,AG,AR,AM,AW,AU,AT,AZ,BS,BH,BD,BB,BY,BE,BZ,BJ,BM,BT,BO,BQ,BA,BW,BV,BR,IO,BN,BG,BF,BI,KH,CM,CA,CV,KY,CF,TD,CL,CN,CX,CC,CO,KM,CG,CD,CK,CR,CI,HR,CU,CW,CY,CZ,DK,DJ,DM,DO,EC,EG,SV,GQ,ER,EE,ET,FK,FO,FJ,FI,FR,GF,PF,TF,GA,GM,GE,DE,GH,GI,GR,GL,GD,GP,GU,GT,GG,GN,GW,GY,HT,HM,VA,HN,HK,HU,IS,IN,ID,IQ,IE,IM,IL,IT,JM,JP,JE,JO,KZ,KE,KI,KR,KW,KG,LA,LV,LB,LS,LR,LY,LI,LT,LU,MO,MK,MG,MW,MY,MV,ML,MT,MH,MQ,MR,MU,YT,MX,FM,MD,MC,MN,ME,MS,MA,MZ,MM,NA,NR,NP,NL,NC,NZ,NI,NE,NG,NU,NF,MP,NO,OM,PK,PW,PS,PA,PG,PY,PE,PH,PN,PL,PT,PR,QA,RE,RO,RU,RW,BL,SH,KN,LC,MF,PM,VC,WS,SM,ST,SA,SN,RS,SC,SL,SG,SX,SK,SI,SB,SO,ZA,GS,SS,ES,LK,SD,SR,SJ,SZ,SE,CH,SY,TW,TJ,TZ,TH,TL,TG,TK,TO,TT,TN,TR,TM,TC,TV,UG,UA,AE,GB,US,UM,UY,UZ,VU,VE,VN,VG,VI,WF,EH,YE,ZM,ZW
+   logo: https://storage.googleapis.com/bitwage-prod-img/Bitwage_LogoSuite_Official.png?v=400026947054681105
+   url: https://www.bitwage.com.br
    
 ############## France ##############
    


### PR DESCRIPTION
I am the founder of Bitwage.  We are the largest bitcoin payroll and invoicing platform.  We allow employees, freelancers, and contracting companies to receive their wages in bitcoin from any US, EU or UK company from anywhere in the world.  We do this by providing US, EU and UK bank accounts to the user which they then provide to companies in that country.  Funds that enter those accounts are then converted to BTC and sent to whatever wallet the user provides.  Our platform is very popular throughout the US, EU and Brazil.

Not sure if you are planning on updating https://www.weusecoins.com/en/how-buy-bitcoins-online-best-bitcoin-exchange-rate-bitcoin-price/ anytime soon, but I think that your users would benefit greatly from knowing about our service.

Thanks,

Jonathan