### PR TITLE
added labels to iOS and Android breadwallet to differentiate

### DIFF
--- a/_data/wallets.yml
+++ b/_data/wallets.yml
@@ -62,7 +62,7 @@
    
 ## Mobile - Android
 
- - wallet: breadwallet
+ - wallet: breadwallet (Android)
    description: <a href="/breadwallet/">Breadwallet</a> started out as the most popular wallet for iPhone, and now it is also available for Adroid devices running Android 6.0 or higher. The simplicity and easy-to-use security makes it a great place to start for users who are new to bitcoin.
    category: mobileandroid 
    download: https://play.google.com/store/apps/details?id=com.breadwallet
@@ -98,7 +98,7 @@
 
 ## Mobile - iOS
 
- - wallet: breadwallet
+ - wallet: breadwallet (iOS)
    description: Breadwallet’s combination of simplicity and security has made it the most popular iOS wallet. iPhone users in search of their first Bitcoin wallet should find <a href="/breadwallet/">Breadwallet</a> easy to understand. 
    category: mobileios 
    download: https://itunes.apple.com/il/app/breadwallet-bitcoin-wallet/id885251393?mt=8


### PR DESCRIPTION
Sorry for the frequent pull requests. After that last update, I realized there is a list of wallets that isn't separated by platform, so I added (iOS) and (Android) tags to the end of the breadwallet entries to differentiate them.