### PR TITLE
Adding cryptex24.com

### DIFF
--- a/_data/buy.yml
+++ b/_data/buy.yml
@@ -104,6 +104,12 @@
    countries: cz, sk, at, be, hr, cy, dk, ee, fi, fr, de, gr, hu, is, ie, it, lv, li, lt, lu, mt, mc, nl, nor, pl, pt, sm, sk, si, es, se, ch, gb, uk
    logo: ccshop.png
    url: https://www.ccshop.info
+   
+ - exchange: Cryptex24
+   description: Fixed rate exchange accepting WU/MG/RIA
+   countries: ad,ae,af,ag,ai,al,am,ao,aq,ar,as,at,au,aw,ax,az,ba,bb,bd,be,bf,bg,bh,bi,bj,bl,bm,bn,bo,bq,br,bs,bt,bv,bw,by,bz,ca,cc,cd,cf,cg,ch,ci,ck,cl,cm,cn,co,cr,cu,cv,cw,cx,cy,cz,de,dj,dk,dm,do,dz,ec,ee,eh,er,es,et,fi,fj,fk,fm,fo,fr,ga,gb,gd,ge,gf,gg,gh,gi,gl,gm,gn,gp,gq,gr,gs,gt,gu,gw,gy,hk,hm,hn,hr,ht,hu,id,ie,il,im,in,io,iq,ir,is,it,je,jm,jo,jp,ke,kg,kh,ki,km,kn,kp,kr,kw,ky,kz,la,lb,lc,li,lk,lr,ls,lt,lu,lv,ly,ma,mc,md,me,mf,mg,mh,mk,ml,mm,mn,mo,mp,mq,mr,ms,mt,mu,mv,mw,mx,my,mz,na,nc,ne,nf,ng,ni,nl,no,np,nr,nu,nz,om,pa,pe,pf,pg,ph,pk,pl,pm,pn,pr,ps,pt,pw,py,qa,re,ro,rs,ru,rw,sa,sb,sc,sd,se,sg,sh,si,sj,sk,sl,sm,sn,so,sr,ss,st,sv,sx,sy,sz,tc,td,tf,tg,th,tj,tk,tl,tm,tn,to,tr,tt,tv,tw,tz,ua,ug,uy,uz,va,vc,ve,vg,vn,vu,wf,ws,ye,yt,za,zm,zw
+   logo: cryptex24.png
+   url: https://cryptex24.com   
 
 ############## United Kingdom ##############
 


### PR DESCRIPTION
Kindly add Cryptex24.com service. It's a fixed rate exchange operating since 2014. It's based in Russia, but operates almost worldwide.