### PR TITLE
Fix mistake in company page

### DIFF
--- a/_companies/zksnacks.md
+++ b/_companies/zksnacks.md
@@ -46,7 +46,7 @@ for .NET Core. Privacy researcher, creator of ZeroLink, co-creator of NTumbleBit
 </ul>
 
 {% for company in site.data.companies %}
-{% if company.company == 'Ascribe' %}
+{% if company.company == 'zkSNACKs' %}
 {% include company_list.html %}
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
This PR fixes a copy/paste mistake while adding Wasabi wallet. Thanks for merging Wasabi. 